### PR TITLE
Henrik/mlir link ifs and reorder

### DIFF
--- a/mlir/include/mlir/Linker/IRMover.h
+++ b/mlir/include/mlir/Linker/IRMover.h
@@ -28,7 +28,7 @@ public:
   MLIRContext *getContext() { return composite->getContext(); }
 
   Error move(OwningOpRef<Operation *> src,
-                    ArrayRef<Operation *> valuesToLink);
+                    ArrayRef<GlobalValueLinkageOpInterface> valuesToLink);
 
   private:
     LinkableModuleOpInterface composite;

--- a/mlir/lib/Linker/Linker.cpp
+++ b/mlir/lib/Linker/Linker.cpp
@@ -24,7 +24,7 @@ class ModuleLinker {
   IRMover &mover;
   OwningOpRef<Operation *> src;
 
-  SetVector<Operation *> valuesToLink;
+  SetVector<GlobalValueLinkageOpInterface> valuesToLink;
 
   /// For symbol clashes, prefer those from src.
   unsigned flags;
@@ -314,7 +314,7 @@ bool ModuleLinker::linkIfNeeded(GlobalValueLinkageOpInterface gv,
   if (dgv && comdatFrom == LinkFrom::Both)
     gvToClone.push_back(linkFromSrc ? dgv.getOperation() : gv.getOperation());
   if (linkFromSrc)
-    valuesToLink.insert(gv.getOperation());
+    valuesToLink.insert(gv);
   return false;
 }
 
@@ -376,8 +376,7 @@ LogicalResult ModuleLinker::run() {
   // }
 
   if (internalizeCallback) {
-    for (auto gv : valuesToLink) {
-      auto gvl = cast<GlobalValueLinkageOpInterface>(gv);
+    for (auto gvl : valuesToLink) {
       internalize.insert(gvl.getLinkedName());
     }
   }

--- a/mlir/test/mlir-link/functions-reverse.mlir
+++ b/mlir/test/mlir-link/functions-reverse.mlir
@@ -1,12 +1,18 @@
 // RUN: mlir-link -split-input-file %s | FileCheck %s
 
-// CHECK:       llvm.func @f2() {
+// CHECK:       llvm.func @f1() {
+// CHECK-NEXT:    llvm.return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  llvm.func @f2() {
 // CHECK-NEXT:    llvm.call @f1() : () -> ()
 // CHECK-NEXT:    llvm.return
 // CHECK-NEXT:  }
-// CHECK-NEXT:  llvm.func @f1() {
-// CHECK-NEXT:    llvm.return
-// CHECK-NEXT:  }
+
+// -----
+
+llvm.func @f1() {
+  llvm.return
+}
 
 // -----
 
@@ -14,11 +20,5 @@ llvm.func @f1()
 
 llvm.func @f2() {
   llvm.call @f1() : () -> ()
-  llvm.return
-}
-
-// -----
-
-llvm.func @f1() {
   llvm.return
 }


### PR DESCRIPTION
@xlauko some incremental progress. Adds reordering of globals the way llvm-link does it. Also, tried to use interfaces rather than `Operation *` when it makes sense (probably more to be done here).