### PR TITLE
Henrik/mlir link simple globals

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -1383,7 +1383,7 @@ def LLVM_GlobalOp : LLVM_Op<"mlir.global",
   }];
 
   let extraClassDefinition = [{
-    bool $cppClass::isDeclarationForLinkage() { return getInitializerRegion().empty(); }
+    bool $cppClass::isDeclarationForLinkage() { return getInitializerRegion().empty() && !getValue(); }
   }];
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;

--- a/mlir/lib/Tools/mlir-link/MlirLinkMain.cpp
+++ b/mlir/lib/Tools/mlir-link/MlirLinkMain.cpp
@@ -12,6 +12,7 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/Verifier.h" // TODO: Remove
 #include "mlir/Linker/Linker.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/ToolUtilities.h"
@@ -299,6 +300,10 @@ LogicalResult mlir::MlirLinkMain(int argc, char **argv,
   if (failed(proc.linkFiles(config.inputFiles)))
     return failure();
 
+  // TODO: Remove
+  if (failed(verify(composite.get(), true))) {
+    llvm::outs() << "Verify failed\n";
+  }
   composite.get()->print(out->os());
   out->keep();
 

--- a/mlir/test/mlir-link/single-global-usage.mlir
+++ b/mlir/test/mlir-link/single-global-usage.mlir
@@ -1,0 +1,12 @@
+// RUN: mlir-link -split-input-file %s | FileCheck %s
+
+// CHECK:  llvm.mlir.global external @number(7 : i32) {addr_space = 0 : i32} : i32
+
+// -----
+
+llvm.mlir.global @number(7 : i32) : i32
+
+
+// -----
+llvm.mlir.global @number() : i32
+

--- a/mlir/test/mlir-link/single-global.mlir
+++ b/mlir/test/mlir-link/single-global.mlir
@@ -1,0 +1,32 @@
+// RUN: mlir-link -split-input-file %s | FileCheck %s
+
+// CHECK:  llvm.mlir.global external @number(7 : i32) {addr_space = 0 : i32} : i32
+// CHECK-NEXT:  llvm.func @f2() -> i32 {
+// CHECK-NEXT:    %0 = llvm.call @f1() : () -> i32
+// CHECK-NEXT:    llvm.return %0 : i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  llvm.func @f1() -> i32 {
+// CHECK-NEXT:    %0 = llvm.mlir.addressof @number : !llvm.ptr
+// CHECK-NEXT:    %1 = llvm.load %0 : !llvm.ptr -> i32
+// CHECK-NEXT:    llvm.return %1 : i32
+// CHECK-NEXT:  }
+
+// -----
+
+llvm.mlir.global @number(7 : i32) : i32
+
+llvm.func @f1() -> i32
+
+llvm.func @f2() -> i32 {
+  %0 = llvm.call @f1() : () -> i32 
+  llvm.return %0 : i32
+}
+
+// -----
+llvm.mlir.global @number() {} : i32
+
+llvm.func @f1() -> i32  {
+  %0 = llvm.mlir.addressof @number : !llvm.ptr
+  %1 = llvm.load %0 : !llvm.ptr -> i32
+  llvm.return %1 : i32
+}


### PR DESCRIPTION
First step to linking variables. Works for simple constants. I also moved verification (which shall later be removed) to the end of processing.