### PR TITLE
Linkage dialect interface

### DIFF
--- a/llvm/lib/Linker/IRMover.cpp
+++ b/llvm/lib/Linker/IRMover.cpp
@@ -606,6 +606,8 @@ Value *IRLinker::materialize(Value *V, bool ForIndirectSymbol) {
     return *NewProto;
 
   // If we already created the body, just return.
+  // TODO: This is too llvm-specific.
+  // Make part of interface isMaterialized method?
   if (auto *F = dyn_cast<Function>(New)) {
     if (!F->isDeclaration())
       return New;

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.h
@@ -241,6 +241,10 @@ SmallVector<IntT> convertArrayToIndices(ArrayAttr attrs) {
   return convertArrayToIndices<IntT>(attrs.getValue());
 }
 
+/// Register the `LLVMLinkerInterface` implementation of `LinkerInterface`
+/// within the LLVM dialect.
+void registerLinkerInterface(DialectRegistry &registry);
+
 } // namespace LLVM
 } // namespace mlir
 

--- a/mlir/include/mlir/InitAllDialects.h
+++ b/mlir/include/mlir/InitAllDialects.h
@@ -165,6 +165,7 @@ inline void registerAllDialects(DialectRegistry &registry) {
   cf::registerBufferDeallocationOpInterfaceExternalModels(registry);
   gpu::registerBufferDeallocationOpInterfaceExternalModels(registry);
   LLVM::registerInlinerInterface(registry);
+  LLVM::registerLinkerInterface(registry);
   linalg::registerAllDialectInterfaceImplementations(registry);
   linalg::registerRuntimeVerifiableOpInterfaceExternalModels(registry);
   memref::registerAllocationOpInterfaceExternalModels(registry);

--- a/mlir/include/mlir/Interfaces/LinkageInterfaces.td
+++ b/mlir/include/mlir/Interfaces/LinkageInterfaces.td
@@ -242,14 +242,15 @@ def GlobalValueLinkageOpInterface : OpInterface<"GlobalValueLinkageOpInterface">
     >,
     InterfaceMethod<
       /*desc=*/        "Returns linked name of the operation",
-      /*returnType=*/  "FailureOr<StringRef>",
+      /*returnType=*/  "StringRef",
       /*methodName=*/  "getLinkedName",
       /*args=*/        (ins),
       /*methodBody=*/  [{}],
       /*defaultImplementation=*/[{
         if (auto symbol = dyn_cast<SymbolOpInterface>($_op.getOperation()))
           return symbol.getName();
-        return emitError($_op.getLoc(), "expected a symbol operation");
+        assert(false && "expected a symbol operation");
+        return "";
       }]
     >
   ];
@@ -276,8 +277,8 @@ def FunctionLinkageOpInterface
   let cppNamespace = "::mlir";
 }
 
-def GlobalFuncLinkageOpInterface
-  : OpInterface<"GlobalFuncLinkageOpInterface",
+def GlobalIFuncLinkageOpInterface
+  : OpInterface<"GlobalIFuncLinkageOpInterface",
                 [GlobalObjectLinkageOpInterface]> {
   let description = [{ WIP }];
   let cppNamespace = "::mlir";

--- a/mlir/include/mlir/Linker/IRMover.h
+++ b/mlir/include/mlir/Linker/IRMover.h
@@ -11,14 +11,11 @@
 
 #include "mlir/IR/BuiltinOps.h"
 
-#include "mlir/Interfaces/LinkageInterfaces.h"
+#include "mlir/Linker/LinkerInterface.h"
 
 using llvm::Error;
 
-namespace mlir {
-
-
-
+namespace mlir::link {
 
 class IRMover {
 public:
@@ -27,13 +24,12 @@ public:
   LinkableModuleOpInterface getComposite() { return composite; }
   MLIRContext *getContext() { return composite->getContext(); }
 
-  Error move(OwningOpRef<Operation *> src,
-                    ArrayRef<GlobalValueLinkageOpInterface> valuesToLink);
+  Error move(OwningOpRef<Operation *> src, ArrayRef<GlobalValue> valuesToLink);
 
-  private:
-    LinkableModuleOpInterface composite;
-  };
+private:
+  LinkableModuleOpInterface composite;
+};
 
-} // namespace mlir
+} // namespace mlir::link
 
 #endif

--- a/mlir/include/mlir/Linker/Linker.h
+++ b/mlir/include/mlir/Linker/Linker.h
@@ -13,7 +13,7 @@
 
 #include "mlir/Interfaces/LinkageInterfaces.h"
 
-namespace mlir {
+namespace mlir::link {
 
 using InternalizeCallbackFn =
     std::function<void(LinkableModuleOpInterface, const StringSet<> &)>;
@@ -97,6 +97,6 @@ private:
   IRMover mover;
 };
 
-} // namespace mlir
+} // namespace mlir::link
 
 #endif

--- a/mlir/include/mlir/Linker/LinkerInterface.h
+++ b/mlir/include/mlir/Linker/LinkerInterface.h
@@ -1,0 +1,34 @@
+//===- LinkerInterface.h - MLIR Linker Interface ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header defines interfaces and utilities necessary for dialects
+// to hook into mlir linker.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_LINKER_LINKAGEDIALECTINTERFACE_H
+#define MLIR_LINKER_LINKAGEDIALECTINTERFACE_H
+
+#include "mlir/IR/DialectInterface.h"
+
+#include "mlir/Interfaces/LinkageInterfaces.h"
+
+namespace mlir {
+
+//===----------------------------------------------------------------------===//
+// LinkageInterface
+//===----------------------------------------------------------------------===//
+
+class LinkerInterface : public DialectInterface::Base<LinkerInterface> {
+public:
+  LinkerInterface(Dialect *dialect) : Base(dialect) {}
+};
+
+} // namespace mlir
+
+#endif // MLIR_LINKER_LINKAGEDIALECTINTERFACE_H

--- a/mlir/include/mlir/Linker/LinkerInterface.h
+++ b/mlir/include/mlir/Linker/LinkerInterface.h
@@ -18,17 +18,420 @@
 
 #include "mlir/Interfaces/LinkageInterfaces.h"
 
-namespace mlir {
+namespace mlir::link {
 
 //===----------------------------------------------------------------------===//
-// LinkageInterface
+// LinkerInterface
 //===----------------------------------------------------------------------===//
+
+using ComdatPair = std::pair<StringRef, ::mlir::link::ComdatSelectionKind>;
+
+struct DenseMapOperationKey {
+  Operation *op;
+};
 
 class LinkerInterface : public DialectInterface::Base<LinkerInterface> {
 public:
   LinkerInterface(Dialect *dialect) : Base(dialect) {}
+
+  virtual bool isDeclaration(GlobalValueLinkageOpInterface op) const {
+    return false;
+  }
+
+  bool isDeclarationForLinker(GlobalValueLinkageOpInterface op) const {
+    if (op.hasAvailableExternallyLinkage())
+      return true;
+    return isDeclaration(op);
+  }
 };
 
-} // namespace mlir
+struct LinkableOp {
+  LinkableOp() = default;
+
+  explicit LinkableOp(Operation *op)
+      : op(op), linker(op ? dyn_cast_or_null<LinkerInterface>(op->getDialect())
+                          : nullptr) {}
+
+  explicit LinkableOp(DenseMapOperationKey op) : op(op.op), linker() {}
+
+  operator bool() const { return op; }
+
+  Operation *getOperation() const { return op; }
+
+protected:
+  Operation *op = nullptr;
+  LinkerInterface *linker = nullptr;
+};
+
+template <typename Op>
+struct LinkableOpDenseMapInfo {
+  static Op getTombstoneKey() {
+    auto *pointer = llvm::DenseMapInfo<::mlir::Operation *>::getEmptyKey();
+    return {::mlir::link::DenseMapOperationKey{pointer}};
+  }
+
+  static Op getEmptyKey() {
+    auto *pointer = llvm::DenseMapInfo<::mlir::Operation *>::getEmptyKey();
+    return {::mlir::link::DenseMapOperationKey{pointer}};
+  }
+
+  static unsigned getHashValue(const Op &val) {
+    return DenseMapInfo<::mlir::Operation *>::getHashValue(val.getOperation());
+  }
+
+  static bool isEqual(const Op &lhs, const Op &rhs) {
+    return lhs.getOperation() == rhs.getOperation();
+  }
+};
+
+template <typename Interface>
+struct OpInterface : LinkableOp {
+  OpInterface() = default;
+  OpInterface(Interface op) : LinkableOp(op) {}
+  OpInterface(DenseMapOperationKey op) : LinkableOp(op) {}
+
+  Interface interface() const { return cast<Interface>(op); }
+  Interface operator*() const { return interface(); }
+
+  operator Interface() { return cast<Interface>(op); }
+  operator Interface() const { return cast<Interface>(op); }
+};
+
+template <typename Interface>
+struct GlobalValueBase : OpInterface<Interface> {
+  using Base = OpInterface<Interface>;
+  using Base::Base;
+  using Base::interface;
+
+  bool isDeclaration() const {
+    return this->linker->isDeclaration(interface());
+  }
+
+  bool isDeclarationForLinker() const {
+    return this->linker->isDeclarationForLinker(interface());
+  }
+
+  bool hasExternalLinkage() const { return interface().hasExternalLinkage(); }
+
+  bool hasAvailableExternallyLinkage() const {
+    return interface().hasAvailableExternallyLinkage();
+  }
+
+  bool hasLinkOnceLinkage() const { return interface().hasLinkOnceLinkage(); }
+
+  bool hasLinkOnceAnyLinkage() const {
+    return interface().hasLinkOnceAnyLinkage();
+  }
+
+  bool hasLinkOnceODRLinkage() const {
+    return interface().hasLinkOnceODRLinkage();
+  }
+
+  bool hasWeakLinkage() const { return interface().hasWeakLinkage(); }
+
+  bool hasWeakAnyLinkage() const { return interface().hasWeakAnyLinkage(); }
+
+  bool hasWeakODRLinkage() const { return interface().hasWeakODRLinkage(); }
+
+  bool hasAppendingLinkage() const { return interface().hasAppendingLinkage(); }
+
+  bool hasInternalLinkage() const { return interface().hasInternalLinkage(); }
+
+  bool hasPrivateLinkage() const { return interface().hasPrivateLinkage(); }
+
+  bool hasLocalLinkage() const { return interface().hasLocalLinkage(); }
+
+  bool hasExternalWeakLinkage() const {
+    return interface().hasExternalWeakLinkage();
+  }
+
+  bool hasCommonLinkage() const { return interface().hasCommonLinkage(); }
+
+  Linkage getLinkage() const { return interface().getLinkage(); }
+
+  void setLinkage(Linkage linkage) { interface().setLinkage(linkage); }
+
+  StringRef getLinkedName() const { return interface().getLinkedName(); }
+
+  void setLinkedName(StringRef name) { llvm_unreachable("Not implemented"); }
+
+  std::optional<StringRef> getComdatName() const {
+    return interface().getComdatName();
+  }
+
+  std::optional<::mlir::link::ComdatPair> getComdatPair() const {
+    return interface().getComdatPair();
+  }
+};
+
+template <typename Interface>
+struct GlobalObjectBase : GlobalValueBase<Interface> {
+  using Base = GlobalValueBase<Interface>;
+  using Base::Base;
+  using Base::interface;
+};
+
+template <typename Interface>
+struct GlobalAliasBase : GlobalValueBase<Interface> {
+  using Base = GlobalValueBase<Interface>;
+  using Base::Base;
+  using Base::interface;
+
+  Operation *getAliasee() const { llvm_unreachable("Not implemented"); }
+};
+
+template <typename Interface>
+struct GlobalVariableBase : GlobalObjectBase<Interface> {
+  using Base = GlobalObjectBase<Interface>;
+  using Base::Base;
+  using Base::interface;
+
+  bool isConstant() const { return interface().isConstant(); }
+
+  void setConstant(bool isConstant) { llvm_unreachable("Not implemented"); }
+
+  // TODO fix this not to be optional
+  std::optional<uint64_t> getAlignment() const {
+    return interface().getAlignment();
+  }
+
+  // TODO fix this not to be optional
+  void setAlignment(std::optional<uint64_t> alignment) {
+    interface().setAlignment(alignment);
+  }
+};
+
+template <typename Interface>
+struct FunctionBase : GlobalObjectBase<Interface> {
+  using Base = GlobalObjectBase<Interface>;
+  using Base::Base;
+  using Base::interface;
+};
+
+template <typename Interface>
+struct GlobalIFuncBase : GlobalObjectBase<Interface> {
+  using Base = GlobalObjectBase<Interface>;
+  using Base::Base;
+  using Base::interface;
+
+  Operation *getResolver() const { llvm_unreachable("Not implemented"); }
+};
+
+struct GlobalValue : GlobalValueBase<GlobalValueLinkageOpInterface> {
+  using GlobalValueBase::GlobalValueBase;
+};
+
+struct GlobalAlias : GlobalAliasBase<GlobalAliasLinkageOpInterface> {
+  using GlobalAliasBase::GlobalAliasBase;
+
+  operator GlobalValue() { return GlobalValue(interface()); }
+  operator GlobalValue() const { return GlobalValue(interface()); }
+};
+
+struct GlobalVariable : GlobalVariableBase<GlobalVariableLinkageOpInterface> {
+  using GlobalVariableBase::GlobalVariableBase;
+
+  operator GlobalValue() { return GlobalValue(interface()); }
+  operator GlobalValue() const { return GlobalValue(interface()); }
+};
+
+struct Function : FunctionBase<FunctionLinkageOpInterface> {
+  using FunctionBase::FunctionBase;
+
+  operator GlobalValue() { return GlobalValue(interface()); }
+  operator GlobalValue() const { return GlobalValue(interface()); }
+};
+
+struct GlobalIFunc : GlobalIFuncBase<GlobalIFuncLinkageOpInterface> {
+  using GlobalIFuncBase::GlobalIFuncBase;
+
+  operator GlobalValue() { return GlobalValue(interface()); }
+  operator GlobalValue() const { return GlobalValue(interface()); }
+};
+
+} // namespace mlir::link
+
+namespace llvm {
+
+///
+/// LinkableOp
+///
+template <typename T>
+struct CastInfo<T, ::mlir::link::LinkableOp>
+    : public NullableValueCastFailed<T>,
+      public DefaultDoCastIfPossible<T, ::mlir::link::LinkableOp &,
+                                     CastInfo<T, ::mlir::link::LinkableOp>> {
+
+  static bool isPossible(::mlir::link::LinkableOp &op) {
+    return T::classof(op.getOperation());
+  }
+
+  static T doCast(::mlir::link::LinkableOp &op) { return T(op.getOperation()); }
+};
+
+template <>
+struct CastInfo<::mlir::link::GlobalAlias, ::mlir::link::LinkableOp>
+    : public NullableValueCastFailed<::mlir::link::GlobalAlias>,
+      public DefaultDoCastIfPossible<
+          ::mlir::link::GlobalAlias, ::mlir::link::LinkableOp &,
+          CastInfo<::mlir::link::GlobalAlias, ::mlir::link::LinkableOp>> {
+
+  static bool isPossible(::mlir::link::LinkableOp &op) {
+    return ::mlir::GlobalAliasLinkageOpInterface::classof(op.getOperation());
+  }
+
+  static ::mlir::link::GlobalAlias doCast(::mlir::link::LinkableOp &op) {
+    return ::mlir::link::GlobalAlias(
+        cast<::mlir::GlobalAliasLinkageOpInterface>(op.getOperation()));
+  }
+};
+
+template <>
+struct CastInfo<::mlir::link::GlobalVariable, ::mlir::link::LinkableOp>
+    : public NullableValueCastFailed<::mlir::link::GlobalVariable>,
+      public DefaultDoCastIfPossible<
+          ::mlir::link::GlobalVariable, ::mlir::link::LinkableOp &,
+          CastInfo<::mlir::link::GlobalVariable, ::mlir::link::LinkableOp>> {
+
+  static bool isPossible(::mlir::link::LinkableOp &op) {
+    return ::mlir::GlobalVariableLinkageOpInterface::classof(op.getOperation());
+  }
+
+  static ::mlir::link::GlobalVariable doCast(::mlir::link::LinkableOp &op) {
+    return ::mlir::link::GlobalVariable(
+        cast<::mlir::GlobalVariableLinkageOpInterface>(op.getOperation()));
+  }
+};
+
+template <>
+struct CastInfo<::mlir::link::Function, ::mlir::link::LinkableOp>
+    : public NullableValueCastFailed<::mlir::link::Function>,
+      public DefaultDoCastIfPossible<
+          ::mlir::link::Function, ::mlir::link::LinkableOp &,
+          CastInfo<::mlir::link::Function, ::mlir::link::LinkableOp>> {
+
+  static bool isPossible(::mlir::link::LinkableOp &op) {
+    return ::mlir::FunctionLinkageOpInterface::classof(op.getOperation());
+  }
+
+  static ::mlir::link::Function doCast(::mlir::link::LinkableOp &op) {
+    return ::mlir::link::Function(
+        cast<::mlir::FunctionLinkageOpInterface>(op.getOperation()));
+  }
+};
+
+template <>
+struct CastInfo<::mlir::link::GlobalIFunc, ::mlir::link::LinkableOp>
+    : public NullableValueCastFailed<::mlir::link::GlobalIFunc>,
+      public DefaultDoCastIfPossible<
+          ::mlir::link::GlobalIFunc, ::mlir::link::LinkableOp &,
+          CastInfo<::mlir::link::GlobalIFunc, ::mlir::link::LinkableOp>> {
+
+  static bool isPossible(::mlir::link::LinkableOp &op) {
+    return ::mlir::GlobalIFuncLinkageOpInterface::classof(op.getOperation());
+  }
+
+  static ::mlir::link::GlobalIFunc doCast(::mlir::link::LinkableOp &op) {
+    return ::mlir::link::GlobalIFunc(
+        cast<::mlir::GlobalIFuncLinkageOpInterface>(op.getOperation()));
+  }
+};
+
+template <typename T>
+struct CastInfo<T, const ::mlir::link::LinkableOp>
+    : public ConstStrippingForwardingCast<
+          T, const ::mlir::link::LinkableOp,
+          CastInfo<T, ::mlir::link::LinkableOp>> {};
+
+template <>
+struct DenseMapInfo<::mlir::link::LinkableOp>
+    : public ::mlir::link::LinkableOpDenseMapInfo<::mlir::link::LinkableOp> {};
+
+///
+/// GlobalAlias
+///
+
+template <>
+struct CastInfo<::mlir::link::GlobalAlias, ::mlir::Operation *>
+    : public CastInfo<::mlir::GlobalAliasLinkageOpInterface,
+                      ::mlir::Operation *> {};
+
+template <typename T>
+struct CastInfo<T, ::mlir::link::GlobalAlias>
+    : public CastInfo<T, ::mlir::link::LinkableOp> {};
+
+template <typename T>
+struct CastInfo<T, const ::mlir::link::GlobalAlias>
+    : public CastInfo<T, const ::mlir::link::LinkableOp> {};
+
+template <>
+struct DenseMapInfo<::mlir::link::GlobalAlias>
+    : public ::mlir::link::LinkableOpDenseMapInfo<::mlir::link::GlobalAlias> {};
+
+///
+/// GlobalValue
+///
+
+template <>
+struct CastInfo<::mlir::link::GlobalValue, ::mlir::Operation *>
+    : public CastInfo<::mlir::GlobalValueLinkageOpInterface,
+                      ::mlir::Operation *> {};
+
+template <typename T>
+struct CastInfo<T, ::mlir::link::GlobalValue>
+    : public CastInfo<T, ::mlir::link::LinkableOp> {};
+
+template <typename T>
+struct CastInfo<T, const ::mlir::link::GlobalValue>
+    : public CastInfo<T, const ::mlir::link::LinkableOp> {};
+
+template <>
+struct DenseMapInfo<::mlir::link::GlobalValue>
+    : public ::mlir::link::LinkableOpDenseMapInfo<::mlir::link::GlobalValue> {};
+
+///
+/// GlobalVariable
+///
+
+template <>
+struct CastInfo<::mlir::link::GlobalVariable, ::mlir::Operation *>
+    : public CastInfo<::mlir::GlobalVariableLinkageOpInterface,
+                      ::mlir::Operation *> {};
+
+template <typename T>
+struct CastInfo<T, ::mlir::link::GlobalVariable>
+    : public CastInfo<T, ::mlir::link::LinkableOp> {};
+
+template <typename T>
+struct CastInfo<T, const ::mlir::link::GlobalVariable>
+    : public CastInfo<T, const ::mlir::link::LinkableOp> {};
+
+template <>
+struct DenseMapInfo<::mlir::link::GlobalVariable>
+    : public ::mlir::link::LinkableOpDenseMapInfo<
+          ::mlir::link::GlobalVariable> {};
+
+///
+/// Function
+///
+
+template <>
+struct CastInfo<::mlir::link::Function, ::mlir::Operation *>
+    : public CastInfo<::mlir::FunctionLinkageOpInterface, ::mlir::Operation *> {
+};
+
+template <typename T>
+struct CastInfo<T, ::mlir::link::Function>
+    : public CastInfo<T, ::mlir::link::LinkableOp> {};
+
+template <typename T>
+struct CastInfo<T, const ::mlir::link::Function>
+    : public CastInfo<T, const ::mlir::link::LinkableOp> {};
+
+template <>
+struct DenseMapInfo<::mlir::link::Function>
+    : public ::mlir::link::LinkableOpDenseMapInfo<::mlir::link::Function> {};
+
+} // namespace llvm
 
 #endif // MLIR_LINKER_LINKAGEDIALECTINTERFACE_H

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3817,8 +3817,22 @@ bool mlir::LLVM::satisfiesLLVMModule(Operation *op) {
 
 namespace {
 
-struct LLVMLinkerInterface : public LinkerInterface {
+struct LLVMLinkerInterface : public ::mlir::link::LinkerInterface {
   using LinkerInterface::LinkerInterface;
+
+  bool isDeclaration(GlobalValueLinkageOpInterface op) const final {
+    if (auto func = dyn_cast<LLVM::LLVMFuncOp>(op.getOperation()))
+      return isDeclaration(func);
+    if (auto global = dyn_cast<LLVM::GlobalOp>(op.getOperation()))
+      return isDeclaration(global);
+    return false;
+  }
+
+  bool isDeclaration(LLVM::LLVMFuncOp op) const { return op.getBody().empty(); }
+
+  bool isDeclaration(LLVM::GlobalOp op) const {
+    return op.getInitializerRegion().empty() && !op.getValue();
+  }
 };
 
 } // end anonymous namespace

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -24,6 +24,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Interfaces/FunctionImplementation.h"
+#include "mlir/Linker/LinkerInterface.h"
 #include "mlir/Transforms/InliningUtils.h"
 
 #include "llvm/ADT/SCCIterator.h"
@@ -3808,4 +3809,22 @@ Value mlir::LLVM::createGlobalString(Location loc, OpBuilder &builder,
 bool mlir::LLVM::satisfiesLLVMModule(Operation *op) {
   return op->hasTrait<OpTrait::SymbolTable>() &&
          op->hasTrait<OpTrait::IsIsolatedFromAbove>();
+}
+
+//===----------------------------------------------------------------------===//
+// LinkageInterface implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct LLVMLinkerInterface : public LinkerInterface {
+  using LinkerInterface::LinkerInterface;
+};
+
+} // end anonymous namespace
+
+void mlir::LLVM::registerLinkerInterface(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, LLVM::LLVMDialect *dialect) {
+    dialect->addInterfaces<LLVMLinkerInterface>();
+  });
 }

--- a/mlir/lib/Linker/IRMover.cpp
+++ b/mlir/lib/Linker/IRMover.cpp
@@ -15,7 +15,11 @@
 #include <assert.h>
 #include <optional>
 
+#define DEBUG_TYPE "mlir-link-ir-mover"
+
 using namespace mlir;
+using namespace mlir::link;
+
 using llvm::Error;
 using llvm::Expected;
 
@@ -39,8 +43,9 @@ public:
   ValueMapper(IRMapping &valueMap, T &materializer)
       : valueMap(valueMap), materializer(materializer) {}
 
-  // TODO: Maybe this should be called remapValue?
-  void scheduleRemapFunction(Operation *v) { worklist.push_back(v); }
+  void scheduleRemapFunction(Function f) {
+    worklist.push_back(f.getOperation());
+  }
 
   Operation *mapSymbol(StringRef sym) {
     // TODO: This is special as we only have a symbol ref and need to get a
@@ -49,39 +54,31 @@ public:
     if (auto op = materializer.getSourceOperation(sym))
       return mapValue(op);
 
-    return nullptr;
+    return {};
   }
 
-  Operation *mapValue(Operation *v) {
+  Operation *mapValue(GlobalValue v) {
     Flusher f(*this);
 
+    Operation *vo = v.getOperation();
     // If the value already exists in the map, use it.
-    if (auto op = valueMap.lookupOrNull(v)) {
+    if (auto op = valueMap.lookupOrNull(vo)) {
       return op;
     }
 
     // If we have a materializer and it can materialize a value, use that.
-    if (auto newv = materializer.materialize(v, false)) {
-      valueMap.map(v, newv);
+    if (auto newv =
+            materializer.materialize(v, /* forIndirectSymbol= */ false)) {
+      valueMap.map(vo, newv);
       return newv;
     }
 
     // Global values do not need to be seeded into the VM if they
     // are using the identity mapping.
-    if (auto gvl = dyn_cast<GlobalValueLinkageOpInterface>(v)) {
-      if (flags & RF_NullMapMissingGlobalValues)
-        return nullptr;
-      valueMap.map(v, v);
-      return v;
-    }
-    // TODO: potentially only value mapping
-
-    // TODO: Inline asm
-
-    // TODO: MetadataAsValue??
-
-    // TODO: Constants etc.
-    assert(false);
+    if (flags & RF_NullMapMissingGlobalValues)
+      return {};
+    valueMap.map(vo, vo);
+    return vo;
   };
 
   bool hasWorkToDo() const { return !worklist.empty(); }
@@ -131,7 +128,7 @@ private:
 
   IRMapping &valueMap;
   T &materializer;
-  RemapFlags flags;
+  RemapFlags flags = RF_None;
 
   // TODO: The worklist is just a function linkage opfor now.
   // Once we add global value init we will need to extend it.
@@ -145,75 +142,84 @@ class MLIRLinker {
   // TODO: This is a ValueToValueMapTy in llvm-link. I'm assuming this would be
   // the equivalent in mlir.
   IRMapping valueMap;
+  IRMapping indirectSymbolValueMap;
 
   ValueMapper<MLIRLinker> mapper;
 
-  DenseSet<GlobalValueLinkageOpInterface> valuesToLink;
-  std::vector<GlobalValueLinkageOpInterface> worklist;
+  DenseSet<GlobalValue> valuesToLink;
+  std::vector<GlobalValue> worklist;
   // Replace-all-uses-with worklist
   std::vector<std::pair<Operation *, Operation *>> rauwWorklist;
+
+  /// The Error encountered during materialization. We use an Optional here to
+  /// avoid needing to manage an unconsumed success value.
+  std::optional<Error> err = std::nullopt;
 
   // NOTE: This is the ValueMapper flush
   void flush();
 
   bool doneLinkingBodies{false};
 
-  void maybeAdd(GlobalValueLinkageOpInterface val) {
+  void maybeAdd(GlobalValue val) {
     if (valuesToLink.insert(val).second)
       worklist.push_back(val);
   }
 
-  std::optional<Error> foundError;
-  void setError(Error e) {
-    if (e)
-      foundError = std::move(e);
-  }
-
-  Error linkFunctionBody(Operation *dst, FunctionLinkageOpInterface src);
-  void linkGlobalVariable(Operation *dst, GlobalVariableLinkageOpInterface src);
-  Error linkGlobalValueBody(Operation *dst, GlobalValueLinkageOpInterface src);
-  bool shouldLink(Operation *dst, Operation *src);
-  Operation *copyGlobalVariableProto(Operation *src);
-  Operation *copyFunctionProto(Operation *src);
-  Operation *copyGlobalValueProto(Operation *src, bool forDefinition);
-  Expected<Operation *> linkGlobalValueProto(GlobalValueLinkageOpInterface sgv,
+  Error linkFunctionBody(Function dst, Function src);
+  Error linkGlobalVariable(GlobalVariable dst, GlobalVariable src);
+  Error linkAliasAliasee(GlobalAlias dst, GlobalAlias src);
+  Error linkIFuncResolver(GlobalIFunc dst, GlobalIFunc src);
+  Error linkGlobalValueBody(GlobalValue dst, GlobalValue src);
+  Expected<Operation *> linkAppendingVarProto(GlobalVariable dst,
+                                              GlobalVariable src);
+  bool shouldLink(GlobalValue dst, GlobalValue src);
+  GlobalVariable copyGlobalVariableProto(GlobalVariable src);
+  Function copyFunctionProto(Function src);
+  GlobalValue copyGlobalValueProto(GlobalValue src, bool forDefinition);
+  Expected<Operation *> linkGlobalValueProto(GlobalValue sgv,
                                              bool forIndirectSymbol);
-  void flushRAUWorklist();
+
+  /// Perform "replace all uses with" operations. These work items need to be
+  /// performed as part of materialization, but we postpone them to happen after
+  /// materialization is done. The materializer called by ValueMapper is not
+  /// expected to delete constants, as ValueMapper is holding pointers to some
+  /// of them, but constant destruction may be indirectly triggered by RAUW.
+  /// Hence, the need to move this out of the materialization call chain.
+  void flushRAUWWorklist();
 
   /// Given a global in the source module, return the global in the
   /// destination module that is being linked to, if any.
-  GlobalValueLinkageOpInterface
-  getLinkedToGlobal(GlobalValueLinkageOpInterface sgv) {
+  GlobalValue getLinkedToGlobal(GlobalValue sgv) {
 
     // If the source has no name it can't link.  If it has local linkage,
     // there is no name match-up going on.
     auto symOp = dyn_cast<SymbolOpInterface>(sgv.getOperation());
     if (!symOp)
-      return nullptr;
+      return {};
 
     auto sgvName = symOp.getName();
     if (sgvName.empty() || sgv.hasLocalLinkage())
-      return nullptr;
+      return {};
 
     // Otherwise see if we have a match in the destination module's symtab.
     // TODO: Should the SymbolTable be a member instead?
     SymbolTable syms(composite);
     Operation *dstOp = syms.lookup(sgvName);
     if (!dstOp)
-      return nullptr;
+      return {};
 
-    auto dgv = dyn_cast<GlobalValueLinkageOpInterface>(dstOp);
+    auto dgv = dyn_cast<GlobalValue>(dstOp);
     if (!dgv)
-      return nullptr;
+      return {};
 
     // If we found a global with the same name in the dest module, but it has
     // internal linkage, we are really not doing any linkage here.
     if (dgv.hasLocalLinkage())
-      return nullptr;
+      return {};
 
     // If we found an intrinsic declaration with mismatching prototypes, we
     // probably had a nameclash. Don't use that version.
-    if (auto fdgv = dyn_cast<FunctionLinkageOpInterface>(sgv.getOperation())) {
+    if (auto fdgv = dyn_cast<Function>(sgv)) {
       // TODO: Can we check for intrinsic functions?
     }
 
@@ -221,147 +227,165 @@ class MLIRLinker {
     return dgv;
   }
 
-  void insertUnique(Operation *op, Operation *dst) {
+  void insertUnique(GlobalValue gv, Operation *dst) {
     // LLVM does global value renaming automatically. This is a workaround to
     // ensure we only insert unique values.
-    bool needsRename = false;
-    if (auto gv = dyn_cast<SymbolOpInterface>(op)) {
-      auto name = gv.getName();
-      SymbolTable syms(dst);
-      if (syms.lookup(name)) {
-        (void)syms.renameToUnique(op, {});
-      }
+
+    Operation *op = gv.getOperation();
+    StringRef name = gv.getLinkedName();
+
+    SymbolTable symbols(dst);
+    if (symbols.lookup(name)) {
+      [[maybe_unused]] auto renamed = symbols.renameToUnique(op, {});
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Renaming global value: " << name << " to "
+                 << (succeeded(renamed) ? renamed->str() : "failed") << "\n");
     }
 
-    OpBuilder b(dst->getRegion(0));
-    b.insert(op);
+    // TODO: make insertion point configurable (let mover keep insertion point)
+    dst->getRegion(0).back().push_back(op);
   }
 
 public:
   MLIRLinker(Operation *composite, OwningOpRef<Operation *> srcOp,
-             ArrayRef<GlobalValueLinkageOpInterface> valuesToLink)
-      : composite{composite}, src{std::move(srcOp)}, mapper{valueMap, *this} {
-    for (GlobalValueLinkageOpInterface gvl : valuesToLink)
+             ArrayRef<GlobalValue> valuesToLink)
+      : composite(composite), src(std::move(srcOp)), mapper(valueMap, *this) {
+    for (GlobalValue gvl : valuesToLink)
       maybeAdd(gvl);
   }
 
   // TODO: Helper function for the materializer to convert a symbol to a
   // linkable value
-  GlobalValueLinkageOpInterface getSourceOperation(StringRef sym) {
+  GlobalValue getSourceOperation(StringRef sym) {
     SymbolTable syms(*src);
     if (auto op = syms.lookup(sym))
-      return dyn_cast<GlobalValueLinkageOpInterface>(op);
-    return nullptr;
+      return dyn_cast<GlobalValue>(op);
+    return {};
   }
 
   Error run();
 
-  Operation *materialize(Operation *v, bool forIndirectSymbol);
+  Operation *materialize(GlobalValue gv, bool forIndirectSymbol);
 };
 
-bool MLIRLinker::shouldLink(Operation *dst, Operation *src) {
-  auto sgv = dyn_cast<GlobalValueLinkageOpInterface>(src);
-  if (!sgv)
-    return false;
+/// TODO: check how this applies to MLIR
+/// The LLVM SymbolTable class autorenames globals that conflict in the symbol
+/// table. This is good for all clients except for us. Go through the trouble
+/// to force this back.
+static void forceRenaming(GlobalValue gv, StringRef name) {
+  // If the global doesn't force its name or if it already has the right name,
+  // there is nothing for us to do.
+  if (gv.hasLocalLinkage() || gv.getLinkedName() == name)
+    return;
 
+  Operation *op = gv.getOperation();
+  SymbolTable symbols(op->getParentOfType<LinkableModuleOpInterface>());
+
+  // If there is a conflict, rename the conflict.
+  if (Operation *conflict = symbols.lookup(name)) {
+    llvm_unreachable("Not implemented");
+  } else {
+    gv.setLinkedName(name); // Force the name back
+  }
+}
+
+bool MLIRLinker::shouldLink(GlobalValue dgv, GlobalValue sgv) {
   if (valuesToLink.count(sgv) || sgv.hasLocalLinkage()) {
     return true;
   }
 
-  if (dst) {
-    if (auto dgv = dyn_cast<GlobalValueLinkageOpInterface>(dst))
-      if (!dgv.isDeclarationForLinkage())
-        return false;
-  }
+  if (dgv && !dgv.isDeclarationForLinker())
+    return false;
 
-  if (sgv.isDeclarationForLinkage() || doneLinkingBodies)
+  if (sgv.isDeclaration() || doneLinkingBodies)
     return false;
 
   // Callback to the client to give a chance to lazily add the Global to the
   // list of value to link.
-  bool LazilyAdded = false;
+  bool lazilyAdded = false;
   //   if (AddLazyFor)
   //     AddLazyFor(SGV, [this, &LazilyAdded](GlobalValue &GV) {
   //       maybeAdd(&GV);
   //       LazilyAdded = true;
   //     });
   // TODO: Implement callback, if needed
-  return LazilyAdded;
+  return lazilyAdded;
 }
 
-Operation *MLIRLinker::copyGlobalVariableProto(Operation *src) {
+// TODO: move to linker interface
+GlobalVariable MLIRLinker::copyGlobalVariableProto(GlobalVariable sgv) {
   // No linking to be performed or linking from the source: simply create an
   // identical version of the symbol over in the dest module... the
   // initializer will be filled in later by LinkGlobalInits.
-  // OpBuilder builder(composite->getRegion(0));
-  auto sgv = dyn_cast<GlobalVariableLinkageOpInterface>(src);
-  Operation *newGv = src->cloneWithoutRegions();
-  if (auto gv = dyn_cast<GlobalVariableLinkageOpInterface>(newGv)) {
-    gv.setLinkage(link::Linkage::External);
-    gv.setAlignment(sgv.getAlignment());
-  }
-  insertUnique(newGv, composite);
-  return newGv;
+  GlobalVariable gv = cast<GlobalVariable>(src->cloneWithoutRegions());
+  gv.setLinkage(link::Linkage::External);
+  gv.setAlignment(sgv.getAlignment());
+  insertUnique(gv, composite);
+  return gv;
 }
 
-Operation *MLIRLinker::copyFunctionProto(Operation *src) {
+Function MLIRLinker::copyFunctionProto(Function src) {
   // Clone the operation (without regions to ensure it becomes empty as is
   // considered a decl)
-  Operation *newFunc = src->cloneWithoutRegions();
-  insertUnique(newFunc, composite);
-  return newFunc;
+
+  // TODO: make this part of linker interface
+  Function func = cast<FunctionLinkageOpInterface>(
+      src.getOperation()->cloneWithoutRegions());
+  insertUnique(func, composite);
+  return func;
 }
-Operation *MLIRLinker::copyGlobalValueProto(Operation *src,
-                                            bool forDefinition) {
-  // TODO: Change signature to accept GlobalValueLinkageOpInterface
-  auto sgv = dyn_cast<GlobalValueLinkageOpInterface>(src);
-  Operation *newOp;
-  if (auto sgvar = dyn_cast<GlobalVariableLinkageOpInterface>(src)) {
-    newOp = copyGlobalVariableProto(src);
-  } else if (auto f = dyn_cast<FunctionLinkageOpInterface>(src)) {
-    newOp = copyFunctionProto(src);
+
+GlobalValue MLIRLinker::copyGlobalValueProto(GlobalValue sgv,
+                                             bool forDefinition) {
+  GlobalValue newgv;
+  if (auto sgvar = dyn_cast<GlobalVariable>(sgv)) {
+    newgv = copyGlobalVariableProto(sgvar);
+  } else if (auto sf = dyn_cast<Function>(sgv)) {
+    newgv = copyFunctionProto(sf);
+  } else {
+    llvm_unreachable("Not implemented");
   }
-  auto newGv = dyn_cast<GlobalValueLinkageOpInterface>(newOp);
-  // TODO: This is unfortunate. Conside changing the return types.
-  if (!newGv)
-    return newGv;
 
-  if (forDefinition || sgv.hasExternalWeakLinkage())
-    newGv.setLinkage(sgv.getLinkage());
+  if (forDefinition) {
+    newgv.setLinkage(sgv.getLinkage());
+  } else if (sgv.hasExternalWeakLinkage()) {
+    newgv.setLinkage(link::Linkage::ExternWeak);
+  }
 
-  // TODO: Copy metadata for global variables and function declarations?
+  // TODO copy metadata?
 
-  // TODO: If function clear personality, prefix and prologue data
-  return newGv;
+  return newgv;
 }
 
-Expected<Operation *>
-MLIRLinker::linkGlobalValueProto(GlobalValueLinkageOpInterface sgv,
-                                 bool forIndirectSymbol) {
-  auto dgv = getLinkedToGlobal(sgv);
+Expected<Operation *> MLIRLinker::linkGlobalValueProto(GlobalValue sgv,
+                                                       bool forIndirectSymbol) {
+  GlobalValue dgv = getLinkedToGlobal(sgv);
 
-  bool shouldLinkOps = shouldLink(dgv.getOperation(), sgv.getOperation());
+  bool shouldLinkOps = shouldLink(dgv, sgv);
 
   // just missing from map
   if (shouldLinkOps) {
-    if (auto existing_dst = valueMap.lookupOrNull(sgv.getOperation()))
-      return existing_dst;
-    // TODO: Check indicrect symbol value map, if needed.
+    Operation *sgvop = sgv.getOperation();
+    if (Operation *inDst = valueMap.lookupOrNull(sgvop))
+      return inDst;
+    if (Operation *inDst = indirectSymbolValueMap.lookupOrNull(sgvop))
+      return inDst;
   }
 
   if (!shouldLinkOps && forIndirectSymbol)
-    dgv = nullptr;
+    dgv = {};
 
   // Handle the ultra special appending linkage case first.
-  // TODO: Appending linkage
-  //   if (src->hasAppendingLinkage() | (dst && dst->hasAppendingLinkage())) {
-  // return liAppendingVarProto()
-  //   }
+  if (sgv.hasAppendingLinkage() || (dgv && dgv.hasAppendingLinkage())) {
+    auto sgvar = cast<GlobalVariable>(sgv);
+    auto dgvar = cast_or_null<GlobalVariable>(dgv);
+    return linkAppendingVarProto(dgvar, sgvar);
+  }
 
   bool needsRenaming = false;
-  Operation *newDst;
+  GlobalValue newgv;
   if (dgv && !shouldLinkOps) {
-    newDst = dgv.getOperation();
+    newgv = dgv;
   } else {
     // If we are done linking global value bodies (i.e. we are performing
     // metadata linking), don't link in the global value due to this
@@ -369,76 +393,90 @@ MLIRLinker::linkGlobalValueProto(GlobalValueLinkageOpInterface sgv,
     if (doneLinkingBodies)
       return nullptr;
 
-    newDst = copyGlobalValueProto(sgv.getOperation(),
-                                  shouldLinkOps || forIndirectSymbol);
-    if (shouldLinkOps) // TODO: || !ForIndirectSymbol?
+    newgv = copyGlobalValueProto(sgv, shouldLinkOps || forIndirectSymbol);
+    if (shouldLinkOps || !forIndirectSymbol)
       needsRenaming = true;
   }
 
-  // TODO: overloaded intrinsics
+  if (isa<Function>(newgv.getOperation())) {
+    // TODO: overloaded intrinsics
+  }
 
-  // if (needsRenaming)
-  //   forceRenaming(newDst, srcName);
+  if (needsRenaming) {
+    forceRenaming(newgv, sgv.getLinkedName());
+  }
 
-  // TODO: Comdat
+  if (shouldLinkOps || forIndirectSymbol) {
+    if (auto sc = sgv.getComdatPair()) {
+      llvm_unreachable("Not implemented");
+    }
+  }
 
   if (!shouldLinkOps && forIndirectSymbol)
-    if (auto newDstGVL = dyn_cast<GlobalValueLinkageOpInterface>(newDst))
-      newDstGVL.setLinkage(link::Linkage::Internal);
+    newgv.setLinkage(link::Linkage::Internal);
 
   // TODO: bitcasts needed??
 
-  if (dgv && newDst != dgv.getOperation()) {
-    // Schedule "replace all uses with"
+  if (dgv && newgv.getOperation() != dgv.getOperation()) {
+    // Schedule "replace all uses with" to happen after materializing is
+    // done. It is not safe to do it now, since ValueMapper may be holding
+    // pointers to constants that will get deleted if RAUW runs.
     rauwWorklist.push_back(
-        std::make_pair(dgv.getOperation(), newDst)); // TODO: This is simplified
+        std::make_pair(dgv.getOperation(), newgv.getOperation()));
   }
 
-  return newDst;
+  return newgv.getOperation();
 }
 
-Operation *MLIRLinker::materialize(Operation *v, bool forIndirectSymbol) {
-  auto sgv = dyn_cast<GlobalValueLinkageOpInterface>(v);
-  if (!sgv)
-    return nullptr;
+Operation *MLIRLinker::materialize(GlobalValue sgv, bool forIndirectSymbol) {
+  LLVM_DEBUG(llvm::dbgs() << "Materializing: " << sgv.getLinkedName() << "\n");
+  // If v is from dst, it was already materialized when dst was loaded.
+  if (composite->isProperAncestor(sgv.getOperation())) {
+    LLVM_DEBUG(llvm::dbgs() << "  already materialized in dst\n");
+    return {};
+  }
 
-  // If v is from dest, it was already materialized when dest was loaded.
-  if (v->getParentOp() == composite)
-    return nullptr;
-
-  // When linking a global from other modules than source & dest, skip
+  // When linking a global from other modules than src and dst, skip
   // materializing it because it would be mapped later when its containing
-  // module is linked. Linking it now would potentially pull in many types that
-  // may not be mapped properly.
-  if (v->getParentOp() != src.get())
-    return nullptr;
+  // module is linked. Linking it now would potentially pull in many types
+  // that may not be mapped properly.
+  if (!src->isProperAncestor(sgv.getOperation())) {
+    LLVM_DEBUG(llvm::dbgs() << "  skipping materialization from non-src\n");
+    return {};
+  }
 
-  auto newProto = linkGlobalValueProto(sgv, false);
+  auto newProto = linkGlobalValueProto(sgv, forIndirectSymbol);
   if (!newProto) {
-    setError(newProto.takeError());
-    return nullptr;
+    err = newProto.takeError();
+    return {};
   }
 
   if (!*newProto)
-    return nullptr;
+    return {};
 
-  GlobalValueLinkageOpInterface newGvl =
-      dyn_cast<GlobalValueLinkageOpInterface>(*newProto);
-  if (!newGvl)
+  GlobalValue newgv = dyn_cast<GlobalValue>(*newProto);
+  if (!newgv)
     return *newProto;
 
+  auto newop = newgv.getOperation();
   // If we already created the body, just return.
-  if (auto f = dyn_cast<GlobalFuncLinkageOpInterface>(newGvl.getOperation())) {
-    if (!f.isDeclarationForLinkage()) {
-      return *newProto;
-    }
-  } else if (auto var = dyn_cast<GlobalVariableLinkageOpInterface>(
-                 newGvl.getOperation())) {
-    if (!var.isDeclarationForLinkage() || var.hasAppendingLinkage())
-      return *newProto;
+  // TODO this should be just `hasMaterializedBody` in linker interface
+  // This is too llvm specific
+  if (auto f = dyn_cast<Function>(newgv)) {
+    if (!f.isDeclaration())
+      return newop;
+  } else if (auto var = dyn_cast<GlobalVariable>(newgv)) {
+    if (!var.isDeclaration() || var.hasAppendingLinkage())
+      return newop;
+  } else if (auto ga = dyn_cast<GlobalAlias>(newgv)) {
+    if (ga.getAliasee())
+      return newop;
+  } else if (auto gi = dyn_cast<GlobalIFunc>(newgv)) {
+    if (gi.getResolver())
+      return newop;
+  } else {
+    llvm_unreachable("Not implemented");
   }
-  // TODO: Lots of if cases for Function, global variable, global alias.
-  // for now, just check if it is a declaration, if so, not much more to do.
 
   // If the global is being linked for an indirect symbol, it may have already
   // been scheduled to satisfy a regular symbol. Similarly, a global being
@@ -448,75 +486,85 @@ Operation *MLIRLinker::materialize(Operation *v, bool forIndirectSymbol) {
   // ValueMap but the value is different, it means that the value already had a
   // definition in the destination module (linkonce for instance), but we need a
   // new definition for the indirect symbol ("New" will be different).
-  // TODO: Some indirect symbol thing
+  Operation *sgvop = sgv.getOperation();
+  if ((forIndirectSymbol && valueMap.lookupOrNull(sgvop)) ||
+      (!forIndirectSymbol &&
+       indirectSymbolValueMap.lookupOrNull(sgvop) == newop)) {
+    return newop;
+  }
 
-  if (forIndirectSymbol || shouldLink(newGvl.getOperation(), v))
-    setError(linkGlobalValueBody(newGvl.getOperation(), sgv));
-
-  // TODO: Update attributes
-  return newGvl.getOperation();
+  if (forIndirectSymbol || shouldLink(newgv, sgv))
+    err = linkGlobalValueBody(newgv, sgv);
+  return newop;
 }
 
-/// Update the initializers in the Dest module now that all globals that may be
-/// referenced are in Dest.
-void MLIRLinker::linkGlobalVariable(Operation *dst,
-                                    GlobalVariableLinkageOpInterface src) {
+/// Update the initializers in the Dest module now that all globals that may
+/// be referenced are in Dest.
+Error MLIRLinker::linkGlobalVariable(GlobalVariable dst, GlobalVariable src) {
   // Figure out what the initializer looks like in the dest module.
   // TODO: Schedule global init
   // TODO: This will likely only need to happen for those that have an
   // initializer, not for constants
+  llvm_unreachable("Not implemented");
+}
+
+Error MLIRLinker::linkAliasAliasee(GlobalAlias dst, GlobalAlias src) {
+  llvm_unreachable("Not implemented");
+}
+
+Error MLIRLinker::linkIFuncResolver(GlobalIFunc dst, GlobalIFunc src) {
+  llvm_unreachable("Not implemented");
 }
 
 /// Copy the source function over into the dest function and fix up references
 /// to values. At this point we know that Dest is an external function, and
 /// that Src is not.
-Error MLIRLinker::linkFunctionBody(Operation *dst,
-                                   FunctionLinkageOpInterface src) {
+Error MLIRLinker::linkFunctionBody(Function dst, Function src) {
+  assert(dst.isDeclaration() && !src.isDeclaration());
 
-  // TODO: Not exactly like this
-  if (auto dgv = dyn_cast<GlobalValueLinkageOpInterface>(dst))
-    assert(dgv.isDeclarationForLinkage());
+  // TODO materialize src if needed
 
-  assert(!src.isDeclarationForLinkage());
+  // TODO deal with prefix data?
+  // TODO deal with prologue data?
+  // TODO deal with personality function?
 
-  assert(src->getNumRegions() == dst->getNumRegions() &&
+  Operation *srcOp = src.getOperation();
+  Operation *dstOp = dst.getOperation();
+  assert(srcOp->getNumRegions() == dstOp->getNumRegions() &&
          "Operations must have same number of regions");
 
   for (auto [srcRegion, dstRegion] :
-       llvm::zip(src->getRegions(), dst->getRegions())) {
+       llvm::zip(srcOp->getRegions(), dstOp->getRegions())) {
     dstRegion.takeBody(srcRegion);
   }
 
-  // TODO: several steps here, copy metadata, steal arg list and schedule
-  // remapfunction. What is needed?
   mapper.scheduleRemapFunction(dst);
-
-  // auto target = src.getOperation()->clone(mapping);
-  // dst->replaceAllUsesWith(target);
-  // dst is an external sym and src is not
   return Error::success();
 }
 
-Error MLIRLinker::linkGlobalValueBody(Operation *dst,
-                                      GlobalValueLinkageOpInterface src) {
-  if (auto f = dyn_cast<FunctionLinkageOpInterface>(src.getOperation()))
-    return linkFunctionBody(dst, f);
-  if (auto gvar =
-          dyn_cast<GlobalVariableLinkageOpInterface>(src.getOperation())) {
-    linkGlobalVariable(dst, gvar);
-    return Error::success();
-  }
-
-  return Error::success();
+// TODO: this should be abstracted as linkGlobalBody interface method
+Error MLIRLinker::linkGlobalValueBody(GlobalValue dst, GlobalValue src) {
+  if (auto f = dyn_cast<Function>(src))
+    return linkFunctionBody(cast<Function>(dst), f);
+  if (auto gv = dyn_cast<GlobalVariable>(src.getOperation()))
+    return linkGlobalVariable(cast<GlobalVariable>(dst), gv);
+  if (auto ga = dyn_cast<GlobalAlias>(src.getOperation()))
+    return linkAliasAliasee(cast<GlobalAlias>(dst), ga);
+  return linkIFuncResolver(cast<GlobalIFunc>(dst), cast<GlobalIFunc>(src));
 }
 
-void MLIRLinker::flushRAUWorklist() {
-  SymbolTable syms(composite);
-  for (const auto &elem : rauwWorklist) {
-    Operation *oldOp, *newOp;
-    std::tie(oldOp, newOp) = elem;
-    if (auto sym = dyn_cast<SymbolOpInterface>(newOp))
-      syms.replaceAllSymbolUses(oldOp, sym.getNameAttr(), composite);
+Expected<Operation *> MLIRLinker::linkAppendingVarProto(GlobalVariable dst,
+                                                        GlobalVariable src) {
+  llvm_unreachable("Not implemented");
+}
+
+void MLIRLinker::flushRAUWWorklist() {
+  for (const auto &[oldOp, newOp] : rauwWorklist) {
+    if (auto sym = dyn_cast<SymbolOpInterface>(newOp)) {
+      auto name = sym.getNameAttr();
+      if (failed(SymbolTable::replaceAllSymbolUses(oldOp, name, composite)))
+        oldOp->emitError("unable to replace all symbol uses for ") << name;
+    }
     oldOp->erase();
   }
   rauwWorklist.clear();
@@ -532,24 +580,24 @@ Error MLIRLinker::run() {
 
   // TODO: Compute type mapping, if needed?
 
-  // reverse the worklist and  process all values
   std::reverse(worklist.begin(), worklist.end());
   while (!worklist.empty()) {
-    auto gvl = worklist.back();
+    GlobalValue gv = worklist.back();
     worklist.pop_back();
 
-    if (valueMap.contains(
-            gvl.getOperation())) // TODO: There is an indirect symbol value map,
-                                 // do we need that?
+    LLVM_DEBUG(llvm::dbgs() << "Linking: " << gv.getLinkedName() << "\n");
+
+    Operation *gvo = gv.getOperation();
+    if (valueMap.contains(gvo) || indirectSymbolValueMap.contains(gvo))
       continue;
 
-    assert(!gvl.isDeclarationForLinkage());
+    assert(!gv.isDeclaration());
 
-    mapper.mapValue(gvl);
+    mapper.mapValue(gv);
 
-    if (foundError)
-      return std::move(*foundError);
-    flushRAUWorklist();
+    if (err)
+      return std::move(*err);
+    flushRAUWWorklist();
   }
 
   doneLinkingBodies = true;
@@ -557,11 +605,11 @@ Error MLIRLinker::run() {
 
   // Reorder the globals just added to the destination module to match their
   // original order in the source module.
-  src->walk([&](GlobalVariableLinkageOpInterface gv) {
+  src->walk([&](GlobalVariable gv) {
     if (gv.hasAppendingLinkage())
       return WalkResult::skip();
     if (auto newValue = mapper.mapValue(gv)) {
-      if (auto newGv = dyn_cast<GlobalVariableLinkageOpInterface>(newValue)) {
+      if (auto newGv = dyn_cast<GlobalVariable>(newValue)) {
         newGv->remove();
         composite->getRegion(0).back().push_back(newGv);
       }
@@ -578,10 +626,8 @@ Error MLIRLinker::run() {
 IRMover::IRMover(Operation *composite) : composite(composite) {}
 
 Error IRMover::move(OwningOpRef<Operation *> src,
-                    ArrayRef<GlobalValueLinkageOpInterface> valuesToLink) {
+                    ArrayRef<GlobalValue> valuesToLink) {
 
   MLIRLinker linker(composite, std::move(src), valuesToLink);
-  Error e = linker.run();
-
-  return e;
+  return linker.run();
 }

--- a/mlir/lib/Tools/mlir-link/MlirLinkMain.cpp
+++ b/mlir/lib/Tools/mlir-link/MlirLinkMain.cpp
@@ -27,6 +27,8 @@
 #include "llvm/Support/WithColor.h"
 
 using namespace mlir;
+using namespace mlir::link;
+
 using namespace llvm;
 
 /// This class is intended to manage the handling of command line options for

--- a/mlir/test/mlir-link/functions.mlir
+++ b/mlir/test/mlir-link/functions.mlir
@@ -8,8 +8,6 @@
 // CHECK-NEXT:    llvm.return
 // CHECK-NEXT:  }
 
-// -----
-
 llvm.func @f1()
 
 llvm.func @f2() {


### PR DESCRIPTION
Introduces linkage interfaces as dialect interface which is better configuration point and does not conflict with MLIR names like `isDeclarataion`, `getName`  etc.

Adds wrapper types that holds both operation and dialect interface, so passing dialect interface is opaque to the user.