### PR TITLE
Initial batch of imported tests from llvm-link

### DIFF
--- a/mlir/test/mlir-link/adapted/2002-07-17-GlobalFail.mlir
+++ b/mlir/test/mlir-link/adapted/2002-07-17-GlobalFail.mlir
@@ -1,0 +1,12 @@
+// RUN: echo "module {}" > %t.tmp.mlir
+// RUN: mlir-link %t.tmp.mlir %s
+module {
+  llvm.mlir.global external constant @X(5 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @Y() {addr_space = 0 : i32, dso_local} : !llvm.array<2 x ptr> {
+    %0 = llvm.mlir.addressof @X : !llvm.ptr
+    %1 = llvm.mlir.undef : !llvm.array<2 x ptr>
+    %2 = llvm.insertvalue %0, %1[0] : !llvm.array<2 x ptr>
+    %3 = llvm.insertvalue %0, %2[1] : !llvm.array<2 x ptr>
+    llvm.return %3 : !llvm.array<2 x ptr>
+  }
+}

--- a/mlir/test/mlir-link/adapted/2002-07-17-LinkTest2.mlir
+++ b/mlir/test/mlir-link/adapted/2002-07-17-LinkTest2.mlir
@@ -1,0 +1,10 @@
+// RUN: echo "module {}" > %t1.mlir
+// RUN: mlir-link %t1.mlir %s
+
+module {
+  llvm.mlir.global external @work() {addr_space = 0 : i32} : !llvm.ptr {
+    %0 = llvm.mlir.addressof @zip : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @zip(i32, i32) -> i32
+}

--- a/mlir/test/mlir-link/adapted/2002-08-20-ConstantExpr.mlir
+++ b/mlir/test/mlir-link/adapted/2002-08-20-ConstantExpr.mlir
@@ -1,0 +1,12 @@
+// RUN: echo "module {}" > %t.LinkTest.mlir
+// RUN: mlir-link %t.LinkTest.mlir %s
+
+module {
+  llvm.mlir.global external @work(4 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global external @test() {addr_space = 0 : i32} : !llvm.ptr {
+    %0 = llvm.mlir.constant(1 : i64) : i64
+    %1 = llvm.mlir.addressof @work : !llvm.ptr
+    %2 = llvm.getelementptr %1[%0] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+    llvm.return %2 : !llvm.ptr
+  }
+}

--- a/mlir/test/mlir-link/adapted/2003-01-30-LinkerRename.mlir
+++ b/mlir/test/mlir-link/adapted/2003-01-30-LinkerRename.mlir
@@ -1,0 +1,26 @@
+// RUN: mlir-link %S/Inputs/2003-01-30-LinkerRename.mlir %s | FileCheck %s
+
+// internal function not resolved properly
+// XFAIL: *
+
+// CHECK:       llvm.mlir.global external @bar() {addr_space = 0 : i32} : !llvm.ptr {
+// CHECK-NEXT:    %0 = llvm.mlir.addressof @foo.2 : !llvm.ptr
+// CHECK-NEXT:    llvm.return %0 : !llvm.ptr
+// CHECK-NEXT:  }
+
+// CHECK:      llvm.func internal @foo.2() -> i32 attributes {dso_local} {
+// CHECK-NEXT:   %0 = llvm.mlir.constant(7 : i32) : i32
+// CHECK-NEXT:   llvm.return %0 : i32
+// CHECK-NEXT: }
+
+// CHECK:      llvm.func @foo() -> i32 {
+// CHECK-NEXT:   %0 = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:   llvm.return %0 : i32
+// CHECK-NEXT: }
+
+module {
+  llvm.func @foo() -> i32 {
+    %0 = llvm.mlir.constant(0 : i32) : i32
+    llvm.return %0 : i32
+  }
+}

--- a/mlir/test/mlir-link/adapted/2003-05-31-LinkerRename.mlir
+++ b/mlir/test/mlir-link/adapted/2003-05-31-LinkerRename.mlir
@@ -1,0 +1,30 @@
+// RUN: mlir-link %S/Inputs/2003-05-31-LinkerRename.mlir %s -o - | FileCheck %s
+
+// internal function not properly resolved
+// XFAIL: *
+
+// CHECK:       llvm.mlir.global external @bar() {addr_space = 0 : i32} : !llvm.ptr {
+// CHECK-NEXT:    %0 = llvm.mlir.addressof @foo.2 : !llvm.ptr
+// CHECK-NEXT:    llvm.return %0 : !llvm.ptr
+// CHECK-NEXT:  }
+
+// CHECK:      llvm.func internal @foo.2() -> i32 attributes {dso_local} {
+// CHECK-NEXT:   %0 = llvm.mlir.constant(7 : i32) : i32
+// CHECK-NEXT:   llvm.return %0 : i32
+// CHECK-NEXT: }
+
+// CHECK:      llvm.func @test() -> i32 {
+// CHECK-NEXT:   %0 = llvm.call @foo() : () -> i32
+// CHECK-NEXT:   llvm.return %0 : i32
+// CHECK-NEXT: }
+
+// CHECK: llvm.func @foo() -> i32
+
+
+module {
+  llvm.func @foo() -> i32
+  llvm.func @test() -> i32 {
+    %0 = llvm.call @foo() : () -> i32
+    llvm.return %0 : i32
+  }
+}

--- a/mlir/test/mlir-link/adapted/AppendingLinkage.mlir
+++ b/mlir/test/mlir-link/adapted/AppendingLinkage.mlir
@@ -1,0 +1,21 @@
+// RUN: echo "module { llvm.mlir.global appending @X(dense<8> : tensor<1xi32>) {addr_space = 0 : i32} : !llvm.array<1 x i32> }" > %t.tmp.mlir
+// RUN: mlir-link %s %t.tmp.mlir | FileCheck %s
+
+// appending linkage not implemeneted
+// XFAIL: *
+
+// CHECK: dense<[7, 4, 8]>
+
+module {
+  llvm.mlir.global appending @X(dense<[7, 4]> : tensor<2xi32>) {addr_space = 0 : i32} : !llvm.array<2 x i32>
+  llvm.mlir.global external @Y() {addr_space = 0 : i32} : !llvm.ptr {
+    %0 = llvm.mlir.addressof @X : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @foo(%arg0: i64) {
+    %0 = llvm.mlir.addressof @X : !llvm.ptr
+    %1 = llvm.mlir.constant(0 : i64) : i64
+    %2 = llvm.getelementptr %0[%1, %arg0] : (!llvm.ptr, i64, i64) -> !llvm.ptr, !llvm.array<2 x i32>
+    llvm.return
+  }
+}

--- a/mlir/test/mlir-link/adapted/AppendingLinkage2.mlir
+++ b/mlir/test/mlir-link/adapted/AppendingLinkage2.mlir
@@ -1,0 +1,11 @@
+// RUN: echo "module { llvm.mlir.global appending @X(dense<8> : tensor<1xi32>) {addr_space = 0 : i32} : !llvm.array<1 x i32> }" > %t.tmp.mlir
+// RUN: mlir-link %s %t.tmp.mlir | FileCheck %s
+
+// appending linkage not yet implemented
+// XFAIL: *
+
+// CHECK: dense<[7, 8]>
+
+module {
+  llvm.mlir.global appending @X(dense<7> : tensor<1xi32>) {addr_space = 0 : i32} : !llvm.array<1 x i32>
+}

--- a/mlir/test/mlir-link/adapted/ConstantGlobals.mlir
+++ b/mlir/test/mlir-link/adapted/ConstantGlobals.mlir
@@ -1,0 +1,13 @@
+// RUN: mlir-link %s %S/Inputs/ConstantGlobals.mlir -o -| FileCheck %s
+// RUN: mlir-link %S/Inputs/ConstantGlobals.mlir %s -o - | FileCheck %s
+
+module {
+// CHECK-DAG: llvm.mlir.global external constant @X(dense<8> : tensor<1xi32>)
+  llvm.mlir.global external @X() {addr_space = 0 : i32} : !llvm.array<1 x i32>
+// CHECK-DAG: llvm.mlir.global external @Y() {addr_space = 0 : i32} : !llvm.array<1 x i32>
+  llvm.mlir.global external @Y() {addr_space = 0 : i32} : !llvm.array<1 x i32>
+  llvm.func @"use-Y"() -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @Y : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+}

--- a/mlir/test/mlir-link/adapted/Inputs/2003-01-30-LinkerRename.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/2003-01-30-LinkerRename.mlir
@@ -1,0 +1,10 @@
+module {
+  llvm.mlir.global external @bar() {addr_space = 0 : i32} : !llvm.ptr {
+    %0 = llvm.mlir.addressof @foo : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func internal @foo() -> i32 attributes {dso_local} {
+    %0 = llvm.mlir.constant(7 : i32) : i32
+    llvm.return %0 : i32
+  }
+}

--- a/mlir/test/mlir-link/adapted/Inputs/2003-05-31-LinkerRename.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/2003-05-31-LinkerRename.mlir
@@ -1,0 +1,10 @@
+module {
+  llvm.mlir.global external @bar() {addr_space = 0 : i32} : !llvm.ptr {
+    %0 = llvm.mlir.addressof @foo : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func internal @foo() -> i32 attributes {dso_local} {
+    %0 = llvm.mlir.constant(7 : i32) : i32
+    llvm.return %0 : i32
+  }
+}

--- a/mlir/test/mlir-link/adapted/Inputs/ConstantGlobals.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/ConstantGlobals.mlir
@@ -1,0 +1,4 @@
+module {
+  llvm.mlir.global external constant @X(dense<8> : tensor<1xi32>) {addr_space = 0 : i32} : !llvm.array<1 x i32>
+  llvm.mlir.global external constant @Y() {addr_space = 0 : i32} : !llvm.array<1 x i32>
+}

--- a/mlir/test/mlir-link/adapted/Inputs/alignment.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/alignment.mlir
@@ -1,0 +1,11 @@
+module {
+  llvm.mlir.global external @A(7 : i32) {addr_space = 0 : i32, alignment = 8 : i64} : i32
+  llvm.mlir.global external @B(7 : i32) {addr_space = 0 : i32, alignment = 4 : i64} : i32
+  llvm.func @C() attributes {alignment = 8 : i64} {
+    llvm.return
+  }
+  llvm.func @D() attributes {alignment = 4 : i64} {
+    llvm.return
+  }
+  llvm.mlir.global common @E(0 : i32) {addr_space = 0 : i32, alignment = 8 : i64} : i32
+}

--- a/mlir/test/mlir-link/adapted/Inputs/available_externally_over_decl.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/available_externally_over_decl.mlir
@@ -1,0 +1,16 @@
+module {
+  llvm.mlir.global external @h() {addr_space = 0 : i32} : !llvm.ptr {
+    %0 = llvm.mlir.addressof @f : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.mlir.global external @h2() {addr_space = 0 : i32} : !llvm.ptr {
+    %0 = llvm.mlir.addressof @g : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func available_externally @f() {
+    llvm.return
+  }
+  llvm.func available_externally @g() {
+    llvm.return
+  }
+}

--- a/mlir/test/mlir-link/adapted/Inputs/basiclink.a.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/basiclink.a.mlir
@@ -1,0 +1,7 @@
+module {
+  llvm.mlir.global external @baz() {addr_space = 0 : i32} : i32
+  llvm.func @foo(%arg0: i32) -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @baz : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+}

--- a/mlir/test/mlir-link/adapted/Inputs/basiclink.b.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/basiclink.b.mlir
@@ -1,0 +1,9 @@
+module {
+  llvm.mlir.global external @baz(0 : i32) {addr_space = 0 : i32} : i32
+  llvm.func @foo(...) -> !llvm.ptr
+  llvm.func @bar() -> !llvm.ptr {
+    %0 = llvm.mlir.constant(123 : i32) : i32
+    %1 = llvm.call @foo(%0) vararg(!llvm.func<ptr (...)>) : (i32) -> !llvm.ptr
+    llvm.return %1 : !llvm.ptr
+  }
+}

--- a/mlir/test/mlir-link/adapted/Inputs/byref-type-input.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/byref-type-input.mlir
@@ -1,0 +1,10 @@
+module {
+  llvm.func @g(%arg0: !llvm.ptr {llvm.byref = !llvm.struct<"a", (i64)>}) {
+    llvm.return
+  }
+  llvm.func @baz(!llvm.ptr {llvm.byref = !llvm.struct<"struct", (i32, i8)>})
+  llvm.func @foo(%arg0: !llvm.ptr {llvm.byref = !llvm.struct<"struct", (i32, i8)>}) {
+    llvm.call @baz(%arg0) : (!llvm.ptr) -> ()
+    llvm.return
+  }
+}

--- a/mlir/test/mlir-link/adapted/Inputs/byval-types-1.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/byval-types-1.mlir
@@ -1,0 +1,7 @@
+module {
+  llvm.func @baz(!llvm.ptr {llvm.byval = !llvm.struct<"struct", (i32, i8)>})
+  llvm.func @foo(%arg0: !llvm.ptr {llvm.byval = !llvm.struct<"struct", (i32, i8)>}) {
+    llvm.call @baz(%arg0) : (!llvm.ptr) -> ()
+    llvm.return
+  }
+}

--- a/mlir/test/mlir-link/adapted/Inputs/comdat.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/comdat.mlir
@@ -1,0 +1,19 @@
+module {
+  llvm.comdat @__llvm_global_comdat {
+    llvm.comdat_selector @foo largest
+    llvm.comdat_selector @qux largest
+    llvm.comdat_selector @any any
+  }
+  llvm.mlir.global external @foo(43 : i64) comdat(@__llvm_global_comdat::@foo) {addr_space = 0 : i32} : i64
+  llvm.mlir.global external @qux(13 : i32) comdat(@__llvm_global_comdat::@qux) {addr_space = 0 : i32} : i32
+  llvm.mlir.global external @in_unselected_group(13 : i32) comdat(@__llvm_global_comdat::@qux) {addr_space = 0 : i32} : i32
+  llvm.mlir.global external @any(7 : i64) comdat(@__llvm_global_comdat::@any) {addr_space = 0 : i32} : i64
+  llvm.func @bar() -> i32 comdat(@__llvm_global_comdat::@foo) {
+    %0 = llvm.mlir.constant(43 : i32) : i32
+    llvm.return %0 : i32
+  }
+  llvm.func @baz() -> i32 comdat(@__llvm_global_comdat::@qux) {
+    %0 = llvm.mlir.constant(13 : i32) : i32
+    llvm.return %0 : i32
+  }
+}

--- a/mlir/test/mlir-link/adapted/Inputs/linkage.a.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/linkage.a.mlir
@@ -1,0 +1,7 @@
+module {
+  llvm.mlir.global linkonce @X(5 : i32) {addr_space = 0 : i32} : i32
+  llvm.func linkonce @foo() -> i32 {
+    %0 = llvm.mlir.constant(7 : i32) : i32
+    llvm.return %0 : i32
+  }
+}

--- a/mlir/test/mlir-link/adapted/Inputs/linkage.b.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/linkage.b.mlir
@@ -1,0 +1,10 @@
+module {
+  llvm.mlir.global external @X() {addr_space = 0 : i32} : i32
+  llvm.func @foo() -> i32
+  llvm.func @bar() {
+    %0 = llvm.mlir.addressof @X : !llvm.ptr
+    %1 = llvm.load %0 {alignment = 4 : i64} : !llvm.ptr -> i32
+    %2 = llvm.call @foo() : () -> i32
+    llvm.return
+  }
+}

--- a/mlir/test/mlir-link/adapted/Inputs/linkage2.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/linkage2.mlir
@@ -1,0 +1,6 @@
+module {
+  llvm.mlir.global weak @test1_a(1 : i8) {addr_space = 0 : i32} : i8
+  llvm.mlir.global external @test2_a() {addr_space = 0 : i32} : i8
+  llvm.mlir.global common @test3_a(0 : i16) {addr_space = 0 : i32} : i16
+  llvm.mlir.global common @test4_a(0 : i16) {addr_space = 0 : i32, alignment = 4 : i64} : i16
+}

--- a/mlir/test/mlir-link/adapted/Inputs/testlink.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/testlink.mlir
@@ -1,0 +1,62 @@
+module {
+  llvm.mlir.global external @GVTy1() {addr_space = 0 : i32} : !llvm.struct<"Ty1", (ptr)> {
+    %0 = llvm.mlir.zero : !llvm.ptr
+    %1 = llvm.mlir.undef : !llvm.struct<"Ty1", (ptr)>
+    %2 = llvm.insertvalue %0, %1[0] : !llvm.struct<"Ty1", (ptr)>
+    llvm.return %2 : !llvm.struct<"Ty1", (ptr)>
+  }
+  llvm.mlir.global external @GVTy2() {addr_space = 0 : i32} : !llvm.struct<"Ty2", opaque>
+  llvm.mlir.global external @MyVar(4 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global external @MyIntList() {addr_space = 0 : i32} : !llvm.struct<"intlist", (ptr, i32)>
+  llvm.mlir.global external constant @AConst(1234 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal constant @Intern1(52 : i32) {addr_space = 0 : i32, dso_local} : i32
+  llvm.mlir.global external @Use2Intern1() {addr_space = 0 : i32} : !llvm.ptr {
+    %0 = llvm.mlir.addressof @Intern1 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.mlir.global external constant @Intern2(12345 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global external constant @MyIntListPtr() {addr_space = 0 : i32} : !llvm.struct<(ptr)> {
+    %0 = llvm.mlir.addressof @MyIntList : !llvm.ptr
+    %1 = llvm.mlir.undef : !llvm.struct<(ptr)>
+    %2 = llvm.insertvalue %0, %1[0] : !llvm.struct<(ptr)>
+    llvm.return %2 : !llvm.struct<(ptr)>
+  }
+  llvm.mlir.global linkonce @MyVarPtr() {addr_space = 0 : i32} : !llvm.struct<(ptr)> {
+    %0 = llvm.mlir.addressof @MyVar : !llvm.ptr
+    %1 = llvm.mlir.undef : !llvm.struct<(ptr)>
+    %2 = llvm.insertvalue %0, %1[0] : !llvm.struct<(ptr)>
+    llvm.return %2 : !llvm.struct<(ptr)>
+  }
+  llvm.mlir.global external constant @mlir.llvm.nameless_global_0(412 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global external @S1GV() {addr_space = 0 : i32} : !llvm.ptr {
+    %0 = llvm.mlir.zero : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @foo(%arg0: i32) -> i32 {
+    %0 = llvm.mlir.addressof @MyVar : !llvm.ptr
+    %1 = llvm.mlir.addressof @MyIntList : !llvm.ptr
+    %2 = llvm.mlir.constant(0 : i64) : i64
+    %3 = llvm.mlir.constant(1 : i32) : i32
+    %4 = llvm.mlir.constant(12 : i32) : i32
+    %5 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    llvm.store %arg0, %0 {alignment = 4 : i64} : i32, !llvm.ptr
+    %6 = llvm.getelementptr %1[%2, 1] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"intlist", (ptr, i32)>
+    llvm.store %4, %6 {alignment = 4 : i64} : i32, !llvm.ptr
+    %7 = llvm.load %5 {alignment = 4 : i64} : !llvm.ptr -> i32
+    %8 = llvm.add %7, %arg0 : i32
+    llvm.return %8 : i32
+  }
+  llvm.func @unimp(f32, f64)
+  llvm.func internal @testintern() attributes {dso_local} {
+    llvm.return
+  }
+  llvm.func @Testintern() {
+    llvm.return
+  }
+  llvm.func internal @testIntern() attributes {dso_local} {
+    llvm.return
+  }
+  llvm.func @VecSizeCrash1(%arg0: !llvm.struct<"VecSize", (vector<10xi32>)>) {
+    llvm.return
+  }
+}

--- a/mlir/test/mlir-link/adapted/Inputs/visibility.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/visibility.mlir
@@ -1,0 +1,30 @@
+module {
+  llvm.comdat @__llvm_global_comdat {
+    llvm.comdat_selector @c1 any
+  }
+  llvm.mlir.global weak hidden @v1(0 : i32) {addr_space = 0 : i32, dso_local} : i32
+  llvm.mlir.global weak protected @v2(0 : i32) {addr_space = 0 : i32, dso_local} : i32
+  llvm.mlir.global weak hidden @v3(0 : i32) {addr_space = 0 : i32, dso_local} : i32
+  llvm.mlir.global external hidden @v4(1 : i32) comdat(@__llvm_global_comdat::@c1) {addr_space = 0 : i32, dso_local} : i32
+  llvm.mlir.alias weak hidden @a1 {dso_local} : i32 {
+    %0 = llvm.mlir.addressof @v1 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.mlir.alias weak protected @a2 {dso_local} : i32 {
+    %0 = llvm.mlir.addressof @v2 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.mlir.alias weak hidden @a3 {dso_local} : i32 {
+    %0 = llvm.mlir.addressof @v3 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func weak hidden @f1() attributes {dso_local} {
+    llvm.return
+  }
+  llvm.func weak protected @f2() attributes {dso_local} {
+    llvm.return
+  }
+  llvm.func weak hidden @f3() attributes {dso_local} {
+    llvm.return
+  }
+}

--- a/mlir/test/mlir-link/adapted/LinkOnce.mlir
+++ b/mlir/test/mlir-link/adapted/LinkOnce.mlir
@@ -1,0 +1,6 @@
+// RUN: echo "module { llvm.mlir.global linkonce @X(8 : i32) {addr_space = 0 : i32} : i32 }" > %t.tmp.mlir
+// RUN: mlir-link %s %t.tmp.mlir -o -
+
+module {
+  llvm.mlir.global linkonce @X(7 : i32) {addr_space = 0 : i32} : i32
+}

--- a/mlir/test/mlir-link/adapted/addrspace.mlir
+++ b/mlir/test/mlir-link/adapted/addrspace.mlir
@@ -1,0 +1,16 @@
+// RUN: mlir-link %s -o - | FileCheck %s
+// REQUIRES: func-addr-space-supp
+
+module {
+  llvm.mlir.global external @G(256 : i32) {addr_space = 2 : i32} : i32
+  // CHECK: @G {{.*}} addr_space = 2
+  llvm.mlir.alias @GA {addr_space = 2 : i32 } : !llvm.ptr {
+  // CHECK: @GA {{.*}} addr_space = 2
+      %0 = llvm.mlir.addressof @G : !llvm.ptr
+      llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @foo() {addr_space = 3 : i32} {
+  // CHECK: @foo {{.*}} addr_space = 3
+    llvm.return
+  }
+}

--- a/mlir/test/mlir-link/adapted/alignment.mlir
+++ b/mlir/test/mlir-link/adapted/alignment.mlir
@@ -1,0 +1,22 @@
+// RUN: mlir-link --sort-symbols %p/alignment.mlir %p/Inputs/alignment.mlir | FileCheck %s
+// RUN: mlir-link --sort-symbols %p/Inputs/alignment.mlir %p/alignment.mlir | FileCheck %s
+
+// alignment not yet resolved
+// XFAIL: *
+
+module {
+  llvm.mlir.global weak @A(7 : i32) {addr_space = 0 : i32, alignment = 4 : i64} : i32
+  // CHECK: llvm.mlir.global @A(7 : i32) {addr_space = 0 : i32, alignment = 8 : i32}
+  llvm.mlir.global weak @B(7 : i32) {addr_space = 0 : i32, alignment = 8 : i64} : i32
+  // CHECK: llvm.mlir.global @B(7 : i32) {addr_space = 0 : i32, alignment = 4 : i32}
+  llvm.func weak @C() attributes {alignment = 4 : i64} {
+    llvm.return
+  }
+  // CHECK: llvm.func @C() attributes {alignment = 8 : i64} {
+  llvm.func weak @D() attributes {alignment = 8 : i64} {
+    llvm.return
+  }
+  // CHECK: llvm.func @D() attributes {alignment = 4 : i64} {
+  llvm.mlir.global common @E(0 : i32) {addr_space = 0 : i32, alignment = 4 : i64} : i32
+  // CHECK: llvm.mlir.global common @E(7 : i32) {addr_space = 0 : i32, alignment = 8 : i32}
+}

--- a/mlir/test/mlir-link/adapted/available_externally_a.mlir
+++ b/mlir/test/mlir-link/adapted/available_externally_a.mlir
@@ -1,0 +1,8 @@
+// RUN: mlir-link %s %p/available_externally_b.mlir -o - | FileCheck %s
+// RUN: mlir-link %s -o - | FileCheck --check-prefix=AE-ONLY %s
+module {
+   llvm.mlir.global available_externally unnamed_addr constant @foo(0 : i32) {addr_space = 0 : i32} : i32
+}
+
+// CHECK: llvm.mlir.global external hidden unnamed_addr constant @foo(0 : i32)
+// AE-ONLY-NOT: @foo

--- a/mlir/test/mlir-link/adapted/available_externally_b.mlir
+++ b/mlir/test/mlir-link/adapted/available_externally_b.mlir
@@ -1,0 +1,5 @@
+// RUN: true
+module {
+  llvm.mlir.global external hidden unnamed_addr constant @foo(0 : i32) {addr_space = 0 : i32, dso_local} : i32
+}
+

--- a/mlir/test/mlir-link/adapted/available_externally_over_decl.mlir
+++ b/mlir/test/mlir-link/adapted/available_externally_over_decl.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-link %s %p/Inputs/available_externally_over_decl.mlir | FileCheck %s
+module {
+  llvm.func @f()
+  llvm.func available_externally @g() {
+    llvm.return
+  }
+  llvm.func @main() -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @f : !llvm.ptr
+    llvm.call @g() : () -> ()
+    llvm.return %0 : !llvm.ptr
+  }
+}
+
+// CHECK-DAG: llvm.func available_externally @g() {
+// CHECK-DAG: llvm.func available_externally @f() {

--- a/mlir/test/mlir-link/adapted/basiclink.mlir
+++ b/mlir/test/mlir-link/adapted/basiclink.mlir
@@ -1,0 +1,2 @@
+// RUN: mlir-link %S/Inputs/basiclink.a.mlir %S/Inputs/basiclink.b.mlir -o %t.mlir
+// RUN: mlir-link %S/Inputs/basiclink.b.mlir %S/Inputs/basiclink.a.mlir -o %t.mlir

--- a/mlir/test/mlir-link/adapted/byref-types.mlir
+++ b/mlir/test/mlir-link/adapted/byref-types.mlir
@@ -1,0 +1,25 @@
+// RUN: mlir-link --sort-symbols %s %p/Inputs/byref-type-input.mlir | FileCheck %s
+
+// CHECK-LABEL: llvm.func @bar()
+// CHECK: llvm.call @foo(%1)
+// CHECK: llvm.func @baz(!llvm.ptr {llvm.byref = !llvm.struct<"struct", (i32, i8)>}
+// CHECK-LABEL: llvm.func @f(%arg0: !llvm.ptr {llvm.byref = !llvm.struct<"a", (i64)>})
+// CHECK-LABEL: llvm.func @foo(%arg0: !llvm.ptr {llvm.byref = !llvm.struct<"struct", (i32, i8)>})
+// CHECK-NEXT: llvm.call @baz(%arg0)
+// CHECK-LABEL: llvm.func @g(%arg0: !llvm.ptr {llvm.byref = !llvm.struct<"a", (i64)>})
+
+module {
+
+  llvm.func @f(%arg0: !llvm.ptr {llvm.byref = !llvm.struct<"a", (i64)>}) {
+    llvm.return
+  }
+  llvm.func @bar() {
+    %0 = llvm.mlir.constant(1 : i32) : i32
+    %1 = llvm.alloca %0 x !llvm.struct<"struct", (i32, i8)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    llvm.call @foo(%1) : (!llvm.ptr) -> ()
+    llvm.return
+  }
+
+
+  llvm.func @foo(!llvm.ptr {llvm.byref = !llvm.struct<"struct", (i32, i8)>})
+}

--- a/mlir/test/mlir-link/adapted/byval-types.mlir
+++ b/mlir/test/mlir-link/adapted/byval-types.mlir
@@ -1,0 +1,17 @@
+// RUN: mlir-link --sort-symbols %s %p/Inputs/byval-types-1.mlir | FileCheck %s
+
+// CHECK: llvm.call @foo(%1)
+// CHECK: llvm.func @baz(!llvm.ptr {llvm.byval = !llvm.struct<"struct", (i32, i8)>})
+// CHECK: llvm.func @foo(%arg0: !llvm.ptr {llvm.byval = !llvm.struct<"struct", (i32, i8)>})
+// CHECK-NEXT: llvm.call @baz(%arg0)
+
+module {
+  llvm.func @foo(!llvm.ptr {llvm.byval = !llvm.struct<"struct", (i32, i8)>})
+  llvm.func @bar() {
+    %0 = llvm.mlir.constant(1 : i32) : i32
+    %1 = llvm.alloca %0 x !llvm.struct<"struct", (i32, i8)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    llvm.call @foo(%1) : (!llvm.ptr) -> ()
+    llvm.return
+  }
+}
+

--- a/mlir/test/mlir-link/adapted/comdat.mlir
+++ b/mlir/test/mlir-link/adapted/comdat.mlir
@@ -1,0 +1,35 @@
+// RUN: mlir-link %s %p/Inputs/comdat.mlir -o - | FileCheck %s
+
+// unimplemented conflict resolution
+// XFAIL: *
+
+module {
+  llvm.comdat @__llvm_global_comdat {
+    llvm.comdat_selector @foo largest
+    llvm.comdat_selector @qux largest
+    llvm.comdat_selector @any any
+  }
+  llvm.mlir.global external @foo(42 : i32) comdat(@__llvm_global_comdat::@foo) {addr_space = 0 : i32} : i32
+  llvm.mlir.global external @qux(12 : i64) comdat(@__llvm_global_comdat::@qux) {addr_space = 0 : i32} : i64
+  llvm.mlir.global external @any(6 : i64) comdat(@__llvm_global_comdat::@any) {addr_space = 0 : i32} : i64
+  llvm.func @bar() -> i32 comdat(@__llvm_global_comdat::@foo) {
+    %0 = llvm.mlir.constant(42 : i32) : i32
+    llvm.return %0 : i32
+  }
+  llvm.func @baz() -> i32 comdat(@__llvm_global_comdat::@qux) {
+    %0 = llvm.mlir.constant(12 : i32) : i32
+    llvm.return %0 : i32
+  }
+}
+
+// CHECK-DAG: llvm.comdat_selector @qux largest
+// CHECK-DAG: llvm.comdat_selector @foo comdat largest
+// CHECK-DAG: llvm.comdat_selector @any any
+
+// CHECK-DAG: llvm.mlir.global @foo(43 : i64) comdat{{$}}
+// CHECK-DAG: llvm.mlir.global @qux(12 : i64) comdat{{$}}
+// CHECK-DAG: llvm.mlir.global @any(6 : i64) comdat{{$}}
+// CHECK-NOT: llvm.mlir.global @in_unselected_group(13 : i32) comdat(@__llvm_global_comdat::@qux)
+
+// CHECK-DAG: llvm.func @baz() -> i32 comdat(@__llvm_global_comdat::@qux) {
+// CHECK-DAG: llvm.func @bar() -> i32 comdat(@__llvm_global_comdat::@foo) {

--- a/mlir/test/mlir-link/adapted/comdat_group.mlir
+++ b/mlir/test/mlir-link/adapted/comdat_group.mlir
@@ -1,0 +1,25 @@
+// RUN: mlir-link %s -o - | FileCheck %s
+
+// comdat disappears when linking
+// XFAIL: *
+
+// CHECK: llvm.comdat_selector @linkoncecomdat any
+// CHECK: llvm.mlir.global linkonce @linkoncecomdat (2 : i32)
+// CHECK: llvm.mlir.global linkonce @linkoncecomdat_unref_var (2 : i32) comdat(@__llvm_global_comdat::@linkoncecomdat)
+// CHECK: llvm.func linkonce @linkoncecomdat_unref_func() comdat(@__llvm_global_comdat::@linkoncecomdat) {
+
+module {
+  llvm.comdat @__llvm_global_comdat {
+    llvm.comdat_selector @linkoncecomdat any
+  }
+  llvm.mlir.global linkonce @linkoncecomdat(2 : i32) comdat(@__llvm_global_comdat::@linkoncecomdat) {addr_space = 0 : i32} : i32
+  llvm.mlir.global linkonce @linkoncecomdat_unref_var(2 : i32) comdat(@__llvm_global_comdat::@linkoncecomdat) {addr_space = 0 : i32} : i32
+  llvm.func linkonce @linkoncecomdat_unref_func() comdat(@__llvm_global_comdat::@linkoncecomdat) {
+    llvm.return
+  }
+  llvm.func @ref_linkoncecomdat() {
+    %0 = llvm.mlir.addressof @linkoncecomdat : !llvm.ptr
+    %1 = llvm.load %0 {alignment = 4 : i64} : !llvm.ptr -> i32
+    llvm.return
+  }
+}

--- a/mlir/test/mlir-link/adapted/link-global-to-func.mlir
+++ b/mlir/test/mlir-link/adapted/link-global-to-func.mlir
@@ -1,0 +1,28 @@
+// RUN: mlir-link -sort-symbols -split-input-file %s | FileCheck %s
+
+// edge case of linking function to global not yet supported
+// XFAIL: *
+
+// CHECK: __eprintf
+module {
+  llvm.mlir.global external @__eprintf() {addr_space = 0 : i32} : !llvm.ptr
+  llvm.func @test() -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @__eprintf : !llvm.ptr
+    %1 = llvm.load %0 {alignment = 8 : i64} : !llvm.ptr -> !llvm.ptr
+    llvm.return %1 : !llvm.ptr
+  }
+}
+
+// -----
+
+module {
+  llvm.func @__eprintf(!llvm.ptr, !llvm.ptr, i32, !llvm.ptr) attributes {passthrough = ["noreturn"]}
+  llvm.func @foo() {
+    %0 = llvm.mlir.undef : !llvm.ptr
+    %1 = llvm.mlir.constant(4 : i32) : i32
+    %2 = llvm.mlir.zero : !llvm.ptr
+    llvm.call tail @__eprintf(%0, %0, %1, %2) {no_unwind} : (!llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
+    llvm.unreachable
+  }
+}
+

--- a/mlir/test/mlir-link/adapted/linkage.mlir
+++ b/mlir/test/mlir-link/adapted/linkage.mlir
@@ -1,0 +1,1 @@
+// RUN: mlir-link %S/Inputs/linkage.a.mlir %S/Inputs/linkage.b.mlir

--- a/mlir/test/mlir-link/adapted/linkage2.mlir
+++ b/mlir/test/mlir-link/adapted/linkage2.mlir
@@ -1,0 +1,16 @@
+// RUN: mlir-link %s %p/Inputs/linkage2.mlir -o - | FileCheck %s
+// RUN: mlir-link %p/Inputs/linkage2.ll %s -o - | FileCheck %s
+
+// broken alignment resolution
+// XFAIL: *
+
+module {
+  llvm.mlir.global common @test1_a(0 : i8) {addr_space = 0 : i32} : i8
+// CHECK-DAG: llvm.mlir.global common @test1_a(0 : i8)
+  llvm.mlir.global external @test2_a(0 : i8) {addr_space = 0 : i32} : i8
+// CHECK-DAG: llvm.mlir.global external @test2_a(0 : i8)
+  llvm.mlir.global common @test3_a(0 : i8) {addr_space = 0 : i32} : i8
+// CHECK-DAG: llvm.mlir.global common @test3_a(0 : i16)
+  llvm.mlir.global common @test4_a(0 : i8) {addr_space = 0 : i32, alignment = 8 : i64} : i8
+// CHECK-DAG: llvm.mlir.global common @test4_a(0 : i16) {addr_space = {[0-9]+} : i32, alignment = 8 : i64}
+}

--- a/mlir/test/mlir-link/adapted/testlink.mlir
+++ b/mlir/test/mlir-link/adapted/testlink.mlir
@@ -1,0 +1,107 @@
+// RUN: mlir-link %s %S/Inputs/testlink.mlir -o - | FileCheck %s
+
+// type renaming is not yet supported
+// XFAIL: *
+
+module {
+  llvm.mlir.global external @S1GV() {addr_space = 0 : i32} : !llvm.struct<"Struct1", opaque>
+  // CHECK: !llvm.struct<"Ty1.1", (ptr)>
+  llvm.mlir.global external @GVTy1() {addr_space = 0 : i32} : !llvm.struct<"Ty1", opaque>
+  // CHECK: !llvm.struct<"Ty2", (ptr, ptr)>
+  llvm.mlir.global external @GVTy2() {addr_space = 0 : i32} : !llvm.struct<"Ty2", (ptr, ptr)> {
+    %0 = llvm.mlir.zero : !llvm.ptr
+    %1 = llvm.mlir.undef : !llvm.struct<"Ty2", (ptr, ptr)>
+    %2 = llvm.insertvalue %0, %1[0] : !llvm.struct<"Ty2", (ptr, ptr)>
+    %3 = llvm.insertvalue %0, %2[1] : !llvm.struct<"Ty2", (ptr, ptr)>
+    llvm.return %3 : !llvm.struct<"Ty2", (ptr, ptr)>
+  }
+  // CHECK-DAG: llvm.mlir.global external @MyIntList {{.*}} !llvm.struct<"intlist", (ptr, i32)> {
+  llvm.mlir.global external @MyIntList() {addr_space = 0 : i32} : !llvm.struct<"intlist", (ptr, i32)> {
+    %0 = llvm.mlir.constant(17 : i32) : i32
+    %1 = llvm.mlir.zero : !llvm.ptr
+    %2 = llvm.mlir.undef : !llvm.struct<"intlist", (ptr, i32)>
+    %3 = llvm.insertvalue %1, %2[0] : !llvm.struct<"intlist", (ptr, i32)>
+    %4 = llvm.insertvalue %0, %3[1] : !llvm.struct<"intlist", (ptr, i32)>
+    llvm.return %4 : !llvm.struct<"intlist", (ptr, i32)>
+  }
+
+  // CHECK-DAG: llvm.mlir.global external @mlir.llvm.nameless_global_0() {addr_space = 0 : i32} : i32
+  llvm.mlir.global external @mlir.llvm.nameless_global_0() {addr_space = 0 : i32} : i32
+
+  // CHECK-DAG: llvm.mlir.global external @Inte(1 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global external @Inte(1 : i32) {addr_space = 0 : i32} : i32
+
+  // CHECK-DAG: llvm.mlir.global internal constant @Intern1(1 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal constant @Intern1(42 : i32) {addr_space = 0 : i32, dso_local} : i32
+  llvm.mlir.global external @UseIntern1() {addr_space = 0 : i32} : !llvm.ptr {
+    %0 = llvm.mlir.addressof @Intern1 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+
+  // CHECK-DAG: llvm.mlir.global internal constant @Intern2.{{[0-9]+}}(1 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal constant @Intern2(792 : i32) {addr_space = 0 : i32, dso_local} : i32
+  llvm.mlir.global external @UseIntern2() {addr_space = 0 : i32} : !llvm.ptr {
+    %0 = llvm.mlir.addressof @Intern2 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+
+  // CHECK-DAG: llvm.mlir.global linkonce @MyVarPtr {{.*}} {
+  llvm.mlir.global linkonce @MyVarPtr() {addr_space = 0 : i32} : !llvm.struct<(ptr)> {
+    %0 = llvm.mlir.addressof @MyVar : !llvm.ptr
+    %1 = llvm.mlir.undef : !llvm.struct<(ptr)>
+    %2 = llvm.insertvalue %0, %1[0] : !llvm.struct<(ptr)>
+    llvm.return %2 : !llvm.struct<(ptr)>
+  }
+  llvm.mlir.global external @UseMyVarPtr() {addr_space = 0 : i32} : !llvm.ptr {
+    %0 = llvm.mlir.addressof @MyVarPtr : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+
+  // CHECK-DAG: llvm.mlir.global linkonce @MyVar(4 : i32)
+  llvm.mlir.global external @MyVar() {addr_space = 0 : i32} : i32
+
+  // CHECK-DAG: llvm.mlir.global linkonce @AConst(1234 : i32)
+  llvm.mlir.global linkonce constant @AConst(123 : i32) {addr_space = 0 : i32} : i32
+
+  // CHECK-DAG: llvm.mlir.global internal constant @Intern1.{{[0-9]+}}(52 : i32)
+  // CHECK-DAG: llvm.mlir.global external constant @Intern2(12345 : i32)
+  // CHECK-DAG: llvm.mlir.global external constant @MyIntListPtr
+  // CHECK-DAG: llvm.mlir.global external constant @mlir.llvm.nameless_global_0(412 : i32)
+
+  llvm.func @use0() -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @foo(i32) -> i32
+  llvm.func @print(i32)
+  llvm.func @main() {
+    %0 = llvm.mlir.addressof @MyVar : !llvm.ptr
+    %1 = llvm.mlir.addressof @MyIntList : !llvm.ptr
+    %2 = llvm.mlir.constant(0 : i64) : i64
+    %3 = llvm.mlir.constant(1 : i32) : i32
+    %4 = llvm.mlir.constant(5 : i32) : i32
+    %5 = llvm.load %0 {alignment = 4 : i64} : !llvm.ptr -> i32
+    llvm.call @print(%5) : (i32) -> ()
+    %6 = llvm.getelementptr %1[%2, 1] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"intlist", (ptr, i32)>
+    %7 = llvm.load %6 {alignment = 4 : i64} : !llvm.ptr -> i32
+    llvm.call @print(%7) : (i32) -> ()
+    %8 = llvm.call @foo(%4) : (i32) -> i32
+    %9 = llvm.load %0 {alignment = 4 : i64} : !llvm.ptr -> i32
+    llvm.call @print(%9) : (i32) -> ()
+    %10 = llvm.load %6 {alignment = 4 : i64} : !llvm.ptr -> i32
+    llvm.call @print(%10) : (i32) -> ()
+    llvm.return
+  }
+  llvm.func internal @testintern() attributes {dso_local} {
+    llvm.return
+  }
+  llvm.func internal @Testintern() attributes {dso_local} {
+    llvm.return
+  }
+  llvm.func @testIntern() {
+    llvm.return
+  }
+  llvm.func @VecSizeCrash(%arg0: !llvm.struct<"VecSize", (vector<5xi32>)>) {
+    llvm.return
+  }
+}

--- a/mlir/test/mlir-link/adapted/visibility.mlir
+++ b/mlir/test/mlir-link/adapted/visibility.mlir
@@ -1,0 +1,46 @@
+// RUN: mlir-link %s %p/Inputs/visibility.mlir -o - | FileCheck %s
+// RUN: mlir-link %p/Inputs/visibility.mlir %s -o - | FileCheck %s
+
+// visibility not yet supported
+// XFAIL: *
+
+module {
+  llvm.comdat @__llvm_global_comdat {
+    llvm.comdat_selector @c1 any
+  }
+// CHECK-DAG: llvm.mlir.global external hidden @v1(0 : i32)
+  llvm.mlir.global external @v1(0 : i32) {addr_space = 0 : i32} : i32
+// CHECK-DAG: llvm.mlir.global external protected @v2(0 : i32)
+  llvm.mlir.global external @v2(0 : i32) {addr_space = 0 : i32} : i32
+// CHECK-DAG: llvm.mlir.global external hidden @v3(0 : i32)
+  llvm.mlir.global external protected @v3(0 : i32) {addr_space = 0 : i32, dso_local} : i32
+// CHECK-DAG: llvm.mlir.global external hidden @v4(0 : i32)
+  llvm.mlir.global external @v4(1 : i32) comdat(@__llvm_global_comdat::@c1) {addr_space = 0 : i32} : i32
+// CHECK-DAG: llvm.mlir.alias external hidden @a1: i32 {
+  llvm.mlir.alias external @a1 : i32 {
+    %0 = llvm.mlir.addressof @v1 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+// CHECK-DAG: llvm.mlir.alias external protected @a2: i32 {
+  llvm.mlir.alias external @a2 : i32 {
+    %0 = llvm.mlir.addressof @v2 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+// CHECK-DAG: llvm.mlir.alias external hidden @a3: i32 {
+  llvm.mlir.alias external protected @a3 {dso_local} : i32 {
+    %0 = llvm.mlir.addressof @v3 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+// CHECK-DAG: llvm.func hidden @f1() {
+  llvm.func @f1() {
+    llvm.return
+  }
+// CHECK-DAG: llvm.func protected @f2() {
+  llvm.func @f2() {
+    llvm.return
+  }
+// CHECK-DAG: llvm.func hidden @f3() {
+  llvm.func protected @f3() attributes {dso_local} {
+    llvm.return
+  }
+}

--- a/mlir/test/mlir-link/adapted/weakextern.mlir
+++ b/mlir/test/mlir-link/adapted/weakextern.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-link %s %s %p/testlink.mlir -o - | FileCheck %s
+
+// CHECK-DAG: llvm.mlir.global extern_weak @kallsyms_names
+// CHECK-DAG: llvm.mlir.global external @Inte
+// CHECK-DAG: llvm.mlir.global external @MyVar
+
+module {
+  llvm.mlir.global extern_weak @kallsyms_names() {addr_space = 0 : i32} : !llvm.array<0 x i8>
+  llvm.mlir.global extern_weak @MyVar() {addr_space = 0 : i32} : i32
+  llvm.mlir.global extern_weak @Inte() {addr_space = 0 : i32} : i32
+  llvm.func weak @use_kallsyms_names() -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @kallsyms_names : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+}


### PR DESCRIPTION
Tests that currently do not pass are marked as expected to fail with `// XFAIL: *`. That way it is easy to notice when a test starts working later on and it can be easily added between supported tests by removing the `XFAIL` directive.