### PR TITLE
Add support for llvm dialect visibility

### DIFF
--- a/mlir/test/mlir-link/adapted/visibility.mlir
+++ b/mlir/test/mlir-link/adapted/visibility.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-link %s %p/Inputs/visibility.mlir -o - | FileCheck %s
 // RUN: mlir-link %p/Inputs/visibility.mlir %s -o - | FileCheck %s
 
-// visibility not yet supported
+// mlir.alias not yet supported; comdat not yet supported
 // XFAIL: *
 
 module {

--- a/mlir/test/mlir-link/visibility-reverse.mlir
+++ b/mlir/test/mlir-link/visibility-reverse.mlir
@@ -1,14 +1,11 @@
+// RUN: mlir-link %s -split-input-file -o - | FileCheck %s
+
 // The values in this chunk are weak the ones in the second chunk are strong,
 // but we should still get the visibility from weak symbols.
-
-llvm.comdat @__llvm_global_comdat {
-  llvm.comdat_selector @c1 any
-}
 
 llvm.mlir.global weak hidden @v1(0 : i32) {addr_space = 0 : i32, dso_local} : i32
 llvm.mlir.global weak protected @v2(0 : i32) {addr_space = 0 : i32, dso_local} : i32
 llvm.mlir.global weak hidden @v3(0 : i32) {addr_space = 0 : i32, dso_local} : i32
-llvm.mlir.global external hidden @v4(1 : i32) comdat(@__llvm_global_comdat::@c1) {addr_space = 0 : i32, dso_local} : i32
 
 llvm.func weak hidden @f1() {
   llvm.return
@@ -22,32 +19,26 @@ llvm.func weak hidden @f3() {
   llvm.return
 }
 
-llvm.comdat @__llvm_global_comdat {
-  llvm.comdat_selector @c1 any
-}
-
 // -----
 
-// CHECK: llvm.mlir.global external hidden @v1(0 : i32)
+// CHECK-DAG: llvm.mlir.global external hidden @v1(0 : i32)
 llvm.mlir.global external @v1(0 : i32) {addr_space = 0 : i32} : i32
-// CHECK: llvm.mlir.global external protected @v2(0 : i32)
+// CHECK-DAG: llvm.mlir.global external protected @v2(0 : i32)
 llvm.mlir.global external @v2(0 : i32) {addr_space = 0 : i32} : i32
-// CHECK: llvm.mlir.global external hidden @v3(0 : i32)
+// CHECK-DAG: llvm.mlir.global external hidden @v3(0 : i32)
 llvm.mlir.global external protected @v3(0 : i32) {addr_space = 0 : i32, dso_local} : i32
-// CHECK: llvm.mlir.global external hidden @v4(1 : i32) comdat(@__llvm_global_comdat::@c1)
-llvm.mlir.global external @v4(1 : i32) comdat(@__llvm_global_comdat::@c1) {addr_space = 0 : i32} : i32
 
-// CHECK: llvm.func hidden @f1()
+// CHECK-DAG: llvm.func hidden @f1()
 llvm.func @f1() {
   llvm.return
 }
 
-// CHECK: llvm.func protected @f2()
+// CHECK-DAG: llvm.func protected @f2()
 llvm.func @f2() {
   llvm.return
 }
 
-// CHECK: llvm.func hidden @f3()
+// CHECK-DAG: llvm.func hidden @f3()
 llvm.func protected @f3() {
   llvm.return
 }

--- a/mlir/test/mlir-link/visibility.mlir
+++ b/mlir/test/mlir-link/visibility.mlir
@@ -1,44 +1,35 @@
+// RUN: mlir-link %s -split-input-file -o - | FileCheck %s
+
 // The values in this chunk are strong the ones in the second chunk are weak,
 // but we should still get the visibility from them.
 
-llvm.comdat @__llvm_global_comdat {
-  llvm.comdat_selector @c1 any
-}
-
-// CHECK: llvm.mlir.global external hidden @v1(0 : i32)
+// CHECK-DAG: llvm.mlir.global external hidden @v1(0 : i32)
 llvm.mlir.global external @v1(0 : i32) {addr_space = 0 : i32} : i32
-// CHECK: llvm.mlir.global external protected @v2(0 : i32)
+// CHECK-DAG: llvm.mlir.global external protected @v2(0 : i32)
 llvm.mlir.global external @v2(0 : i32) {addr_space = 0 : i32} : i32
-// CHECK: llvm.mlir.global external hidden @v3(0 : i32)
+// CHECK-DAG: llvm.mlir.global external hidden @v3(0 : i32)
 llvm.mlir.global external protected @v3(0 : i32) {addr_space = 0 : i32, dso_local} : i32
-// CHECK: llvm.mlir.global external hidden @v4(1 : i32) comdat(@__llvm_global_comdat::@c1)
-llvm.mlir.global external @v4(1 : i32) comdat(@__llvm_global_comdat::@c1) {addr_space = 0 : i32} : i32
 
-// CHECK: llvm.func hidden @f1()
+// CHECK-DAG: llvm.func hidden @f1()
 llvm.func @f1() {
   llvm.return
 }
 
-// CHECK: llvm.func protected @f2()
+// CHECK-DAG: llvm.func protected @f2()
 llvm.func @f2() {
   llvm.return
 }
 
-// CHECK: llvm.func hidden @f3()
+// CHECK-DAG: llvm.func hidden @f3()
 llvm.func protected @f3() {
   llvm.return
 }
 
 // -----
 
-llvm.comdat @__llvm_global_comdat {
-  llvm.comdat_selector @c1 any
-}
-
 llvm.mlir.global weak hidden @v1(0 : i32) {addr_space = 0 : i32, dso_local} : i32
 llvm.mlir.global weak protected @v2(0 : i32) {addr_space = 0 : i32, dso_local} : i32
 llvm.mlir.global weak hidden @v3(0 : i32) {addr_space = 0 : i32, dso_local} : i32
-llvm.mlir.global external hidden @v4(1 : i32) comdat(@__llvm_global_comdat::@c1) {addr_space = 0 : i32, dso_local} : i32
 
 llvm.func weak hidden @f1() {
   llvm.return


### PR DESCRIPTION
Enable "basic" tests for visibility. Some parts were removed because they are not yet supported, but they are present in the the adapted tests from llvm-link. Those will be enabled when necessary features (comdat, llvm.mlir.alias) parts are supported.