### PR TITLE
[mlir][LLVM] Make LLVMStructType parser rename on collision

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
@@ -196,6 +196,10 @@ def LLVMStructType : LLVMType<"LLVMStruct", "struct", [
                                            ArrayRef<Type> elements,
                                            bool isPacked = false);
 
+    static LLVMStructType getUniquedIdentified(MLIRContext *context, StringRef name,
+                                           ArrayRef<Type> elements,
+                                           bool isPacked = false);
+
     /// Gets or creates a literal struct with the given body in the provided
     /// context.
     static LLVMStructType getLiteral(MLIRContext *context, ArrayRef<Type> types,

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
@@ -433,6 +433,22 @@ LLVMStructType LLVMStructType::getIdentifiedChecked(
   return Base::getChecked(emitError, context, name, /*opaque=*/false);
 }
 
+LLVMStructType LLVMStructType::getUniquedIdentified(MLIRContext *context,
+                                                StringRef name,
+                                                ArrayRef<Type> elements,
+                                                bool isPacked) {
+  std::string stringName = name.str();
+  unsigned counter = 0;
+  do {
+    auto type = LLVMStructType::getIdentified(context, stringName);
+    if (failed(type.setBody(elements, isPacked))) {
+      stringName = (Twine(name) + "." + Twine(counter++)).str();
+      continue;
+    }
+    return type;
+  } while (true);
+}
+
 LLVMStructType LLVMStructType::getNewIdentified(MLIRContext *context,
                                                 StringRef name,
                                                 ArrayRef<Type> elements,

--- a/mlir/test/Dialect/LLVMIR/struct_type_conflict.mlir
+++ b/mlir/test/Dialect/LLVMIR/struct_type_conflict.mlir
@@ -1,0 +1,29 @@
+// RUN: mlir-opt %s -o - | FileCheck %s
+
+module {
+  llvm.func @foo(%arg0: i32) -> i32 attributes {dso_local} {
+    %0 = llvm.mlir.constant(1 : i32) : i32
+    %1 = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: !llvm.struct<"struct.S", (i32)>
+    %2 = llvm.alloca %0 x !llvm.struct<"struct.S", (i32)> {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.getelementptr inbounds %2[%1, 0] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"struct.S", (i32)>
+    llvm.store %arg0, %3 {alignment = 4 : i64} : i32, !llvm.ptr
+    %4 = llvm.getelementptr inbounds %2[%1, 0] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"struct.S", (i32)>
+    %5 = llvm.load %4 {alignment = 4 : i64} : !llvm.ptr -> i32
+    llvm.return %5 : i32
+  }
+}
+
+module {
+  llvm.func @getX(%arg0: !llvm.struct<"struct.S", (i32, i1, i32)>) -> i32 attributes {dso_local} {
+    %0 = llvm.mlir.constant(1 : i32) : i32
+    %1 = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: !llvm.struct<"struct.S.0", (i32, i1, i32)>
+    %2 = llvm.alloca %0 x !llvm.struct<"struct.S", (i32, i1, i32)> {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.getelementptr inbounds %2[%1, 0] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"struct.S", (i32, i1, i32)>
+    llvm.store %arg0, %3 {alignment = 4 : i64} : !llvm.struct<"struct.S", (i32, i1, i32)>, !llvm.ptr
+    %4 = llvm.getelementptr inbounds %2[%1, 0] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"struct.S", (i32, i1, i32)>
+    %5 = llvm.load %4 {alignment = 4 : i64} : !llvm.ptr -> i32
+    llvm.return %5 : i32
+  }
+}

--- a/mlir/test/Dialect/LLVMIR/types-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/types-invalid.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt --allow-unregistered-dialect -split-input-file -verify-diagnostics %s
+// REQUIRES: modified-named-struct-type-parser
 
 func.func @array_of_void() {
   // expected-error @+1 {{invalid array element type}}


### PR DESCRIPTION
This is a workaround for importing multiple modules into a single context. The downside of this solution is that it accepts invalid IRs where there is a redefinition of the named type in a single module, but solving that in the parser is not currently possible.