### PR TITLE
[CIR] Initialize frontend `MLIRTargetDialect` flag

### DIFF
--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -453,7 +453,7 @@ public:
   std::string ClangIRIdiomRecognizerOpts;
   std::string ClangIRLibOptOpts;
 
-  frontend::MLIRDialectKind MLIRTargetDialect;
+  frontend::MLIRDialectKind MLIRTargetDialect = frontend::MLIR_CORE;
 
   /// The input kind, either specified via -x argument or deduced from the input
   /// file name.


### PR DESCRIPTION
UBSan complains when I use clang from `main`:

```
/Users/tnytown/Documents/sw/instafix-llvm/llvm/out/build/macos/tools/clang/include/clang/Driver/Options.inc:10417:1: runtime error: load of value 3200171710, which is not a valid value for type 'frontend::MLIRDialectKind'
SUMMARY: UndefinedBehaviorSanitizer: invalid-enum-load /Users/tnytown/Documents/sw/instafix-llvm/llvm/out/build/macos/tools/clang/include/clang/Driver/Options.inc:10417:1 
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.	Program arguments: /Users/tnytown/Documents/sw/instafix-llvm/llvm/out/install/macos/bin/clang-21 -cc1 -triple arm64-apple-macosx11.3.0 -Wundef-prefix=TARGET_OS_ -Werror=undef-prefix -Wdeprecated-objc-isa-usage -Werror=deprecated-objc-isa-usage -emit-llvm -disable-free -clear-ast-before-backend -main-file-name test.c -mrelocation-model pic -pic-level 2 -mframe-pointer=non-leaf -ffp-contract=on -fno-rounding-math -funwind-tables=1 -target-sdk-version=11.3 -fcompatibility-qualified-id-block-type-checking -fvisibility-inlines-hidden-static-local-var -fbuiltin-headers-in-system-modules -fdefine-target-os-macros -enable-tlsdesc -target-cpu apple-m1 -target-feature +zcm -target-feature +zcz -target-feature +v8.4a -target-feature +aes -target-feature +altnzcv -target-feature +ccdp -target-feature +ccpp -target-feature +complxnum -target-feature +crc -target-feature +dotprod -target-feature +flagm -target-feature +fp-armv8 -target-feature +fp16fml -target-feature +fptoint -target-feature +fullfp16 -target-feature +jsconv -target-feature +lse -target-feature +neon -target-feature +pauth -target-feature +perfmon -target-feature +predres -target-feature +ras -target-feature +rcpc -target-feature +rdm -target-feature +sb -target-feature +sha2 -target-feature +sha3 -target-feature +specrestrict -target-feature +ssbs -target-abi darwinpcs -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=/Users/tnytown/Documents/sw/instafix -target-linker-version 954.16 -v -fcoverage-compilation-dir=/Users/tnytown/Documents/sw/instafix -resource-dir /Users/tnytown/Documents/sw/instafix-llvm/llvm/out/install/macos/lib/clang/21 -isysroot /nix/store/afinrggjfrk7q9pb7rv50l50cj0y0l63-apple-sdk-11.3/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -internal-isystem /nix/store/afinrggjfrk7q9pb7rv50l50cj0y0l63-apple-sdk-11.3/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/local/include -internal-isystem /Users/tnytown/Documents/sw/instafix-llvm/llvm/out/install/macos/lib/clang/21/include -internal-externc-isystem /nix/store/afinrggjfrk7q9pb7rv50l50cj0y0l63-apple-sdk-11.3/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include -source-date-epoch 315532800 -O3 -ferror-limit 19 -stack-protector 1 -fblocks -fencode-extended-block-signature -fregister-global-dtors-with-atexit -fgnuc-version=4.2.1 -fskip-odr-check-in-gmf -fmax-type-align=16 -fcolor-diagnostics -vectorize-loops -vectorize-slp -D__GCC_HAVE_DWARF2_CFI_ASM=1 -o /Users/tnytown/Documents/sw/instafix/out/build/vcpkg-nix/test/Output/spec_compilation_test.pkx.tmp_test.ll -x c /Users/tnytown/Documents/sw/instafix/out/build/vcpkg-nix/test/Output/spec_compilation_test.pkx.tmp/test.c -emit-mlir=llvm
 #0 0x0000000112c9663c llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/tnytown/Documents/sw/instafix-llvm/llvm/out/install/macos/lib/libLLVMSupport.dylib+0x3ca63c)
 #1 0x0000000112c97704 SignalHandler(int, __siginfo*, void*) (/Users/tnytown/Documents/sw/instafix-llvm/llvm/out/install/macos/lib/libLLVMSupport.dylib+0x3cb704)
 #2 0x0000000197454624 (/usr/lib/system/libsystem_platform.dylib+0x1804ac624)
 #3 0x000000019741a88c (/usr/lib/system/libsystem_pthread.dylib+0x18047288c)
 #4 0x0000000197323c60 (/usr/lib/system/libsystem_c.dylib+0x18037bc60)
 #5 0x000000010fd5e128 __sanitizer::Atexit(void (*)()) (/nix/store/z9kak8igick9x3d4lvfg2w6pxglqyqzp-compiler-rt-libc-20.1.3/lib/darwin/libclang_rt.asan_osx_dynamic.dylib+0x86128)
 #6 0x000000010fd5d4fc __sanitizer::Die() (/nix/store/z9kak8igick9x3d4lvfg2w6pxglqyqzp-compiler-rt-libc-20.1.3/lib/darwin/libclang_rt.asan_osx_dynamic.dylib+0x854fc)
 #7 0x000000010fd77150 __ubsan_handle_implicit_conversion (/nix/store/z9kak8igick9x3d4lvfg2w6pxglqyqzp-compiler-rt-libc-20.1.3/lib/darwin/libclang_rt.asan_osx_dynamic.dylib+0x9f150)
 #8 0x000000010d6ab4ec ParseFrontendArgs(clang::FrontendOptions&, llvm::opt::ArgList&, clang::DiagnosticsEngine&, bool&) /Users/tnytown/Documents/sw/instafix-llvm/llvm/out/build/macos/tools/clang/include/clang/Driver/Options.inc:10417:1
 #9 0x000000010d696130 clang::CompilerInvocation::CreateFromArgsImpl(clang::CompilerInvocation&, llvm::ArrayRef<char const*>, clang::DiagnosticsEngine&, char const*) /Users/tnytown/Documents/sw/instafix-llvm/clang/lib/Frontend/CompilerInvocation.cpp:0:3
#10 0x000000010d62ed90 RoundTrip(llvm::function_ref<bool (clang::CompilerInvocation&, llvm::ArrayRef<char const*>, clang::DiagnosticsEngine&, char const*)>, llvm::function_ref<void (clang::CompilerInvocation&, llvm::SmallVectorImpl<char const*>&, llvm::function_ref<char const* (llvm::Twine const&)>)>, clang::CompilerInvocation&, clang::CompilerInvocation&, llvm::ArrayRef<char const*>, clang::DiagnosticsEngine&, char const*, bool, bool) /Users/tnytown/Documents/sw/instafix-llvm/clang/lib/Frontend/CompilerInvocation.cpp:852:67
#11 0x000000010d6bc918 clang::CompilerInvocation::CreateFromArgs(clang::CompilerInvocation&, llvm::ArrayRef<char const*>, clang::DiagnosticsEngine&, char const*) /Users/tnytown/Documents/sw/instafix-llvm/clang/lib/Frontend/CompilerInvocation.cpp:5121:10
#12 0x000000010212eaac cc1_main(llvm::ArrayRef<char const*>, char const*, void*) (/Users/tnytown/Documents/sw/instafix-llvm/llvm/out/install/macos/bin/clang-21+0x100016aac)
#13 0x0000000102125840 ExecuteCC1Tool(llvm::SmallVectorImpl<char const*>&, llvm::ToolContext const&) (/Users/tnytown/Documents/sw/instafix-llvm/llvm/out/install/macos/bin/clang-21+0x10000d840)
#14 0x000000010212310c clang_main(int, char**, llvm::ToolContext const&) (/Users/tnytown/Documents/sw/instafix-llvm/llvm/out/install/macos/bin/clang-21+0x10000b10c)
#15 0x00000001021565c0 main (/Users/tnytown/Documents/sw/instafix-llvm/llvm/out/install/macos/bin/clang-21+0x10003e5c0)
#16 0x000000019707ab98 
```

Turns out this is related to the `emit-mlir` flag. I'm not sure if initializing this is the correct way to go about it but UBSan no longer complains with this change applied.