### PR TITLE
Prefer emitting indirect calls if possible

### DIFF
--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -1802,11 +1802,11 @@ LogicalResult ModuleImport::convertInstruction(llvm::Instruction *inst) {
         return failure();
 
       FlatSymbolRefAttr callee = nullptr;
-      if (isIncompatibleCall) {
+      FlatSymbolRefAttr calleeSym = convertCalleeName(callInst);
+      if (calleeSym) {
         // Use an indirect call (in order to represent valid and verifiable LLVM
         // IR). Build the indirect call by passing an empty `callee` operand and
         // insert into `operands` to include the indirect call target.
-        FlatSymbolRefAttr calleeSym = convertCalleeName(callInst);
         Value indirectCallVal = builder.create<LLVM::AddressOfOp>(
             loc, LLVM::LLVMPointerType::get(context), calleeSym);
         operands->insert(operands->begin(), indirectCallVal);


### PR DESCRIPTION
This is a hack in order to make the `lencod` test compile

**NOTE(ekilmer, June 9):** Let's hold off on merging this until we understand the consequences of how this affects static analysis results. We can skip the affected tests in the meantime.