### PR TITLE
[MLIR][LLVM] Hack in "linking" of opaque types with bodies during parsing

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
@@ -229,7 +229,7 @@ def LLVMStructType : LLVMType<"LLVMStruct", "struct", [
     /// different thread modified the struct after it was created. Most callers
     /// are likely to assert this always succeeds, but it is possible to implement
     /// a local renaming scheme based on the result of this call.
-    LogicalResult setBody(ArrayRef<Type> types, bool isPacked);
+    LogicalResult setBody(ArrayRef<Type> types, bool isPacked, bool forceOpaqueRedef = false);
 
     /// Checks if a struct is packed.
     bool isPacked() const;

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMTypeSyntax.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMTypeSyntax.cpp
@@ -218,10 +218,6 @@ Type LLVMStructType::parse(AsmParser &parser) {
       return LLVMStructType();
     auto type = LLVMStructType::getOpaqueChecked(
         [loc] { return emitError(loc); }, loc.getContext(), name);
-    if (!type.isOpaque()) {
-      parser.emitError(kwLoc, "redeclaring defined struct as opaque");
-      return LLVMStructType();
-    }
     return type;
   }
 

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
@@ -443,7 +443,7 @@ LLVMStructType LLVMStructType::getUniquedIdentified(MLIRContext *context,
   unsigned counter = 1;
   do {
     auto type = LLVMStructType::getIdentified(context, stringName);
-    if (failed(type.setBody(elements, isPacked))) {
+    if (failed(type.setBody(elements, isPacked, /* forceOpaqueRedef = */ true))) {
       stringName = (Twine(name) + "." + Twine(counter++)).str();
       continue;
     }
@@ -490,11 +490,11 @@ LLVMStructType::getOpaqueChecked(function_ref<InFlightDiagnostic()> emitError,
   return Base::getChecked(emitError, context, name, /*opaque=*/true);
 }
 
-LogicalResult LLVMStructType::setBody(ArrayRef<Type> types, bool isPacked) {
+LogicalResult LLVMStructType::setBody(ArrayRef<Type> types, bool isPacked, bool forceOpaqueRedef) {
   assert(isIdentified() && "can only set bodies of identified structs");
   assert(llvm::all_of(types, LLVMStructType::isValidElementType) &&
          "expected valid body types");
-  return Base::mutate(types, isPacked);
+  return Base::mutate(types, isPacked, forceOpaqueRedef);
 }
 
 bool LLVMStructType::isPacked() const { return getImpl()->isPacked(); }

--- a/mlir/lib/Dialect/LLVMIR/IR/TypeDetail.h
+++ b/mlir/lib/Dialect/LLVMIR/IR/TypeDetail.h
@@ -240,13 +240,14 @@ public:
   /// if the struct is marked as intentionally opaque. The struct will be marked
   /// as initialized as a result of this operation and can no longer be changed.
   LogicalResult mutate(TypeStorageAllocator &allocator, ArrayRef<Type> body,
-                       bool packed) {
+                       bool packed, bool forceOpaqueRedef) {
     if (!isIdentified())
       return failure();
-    if (isInitialized())
+    if (isInitialized() && !(forceOpaqueRedef && isOpaque()))
       return success(!isOpaque() && body == getIdentifiedStructBody() &&
                      packed == isPacked());
 
+    llvm::Bitfield::set<MutableFlagOpaque>(identifiedBodySizeAndFlags, false);
     llvm::Bitfield::set<MutableFlagInitialized>(identifiedBodySizeAndFlags,
                                                 true);
     llvm::Bitfield::set<MutableFlagPacked>(identifiedBodySizeAndFlags, packed);

--- a/mlir/test/mlir-link/adapted/Inputs/opaque.mlir
+++ b/mlir/test/mlir-link/adapted/Inputs/opaque.mlir
@@ -1,0 +1,18 @@
+module {
+  llvm.mlir.global external @g2() {addr_space = 0 : i32} : !llvm.struct<"A", ()>
+  llvm.mlir.global external @g3() {addr_space = 0 : i32} : !llvm.struct<"B", (struct<"D", (struct<"E", opaque>)>, struct<"E", opaque>, ptr)>
+  llvm.func @f1() {
+    %0 = llvm.mlir.zero : !llvm.ptr
+    %1 = llvm.mlir.constant(0 : i32) : i32
+    %2 = llvm.getelementptr %0[%1] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"A", ()>
+    llvm.return
+  }
+  llvm.func @use_g2() -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @g2 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @use_g3() -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @g3 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+}

--- a/mlir/test/mlir-link/adapted/opaque.mlir
+++ b/mlir/test/mlir-link/adapted/opaque.mlir
@@ -1,0 +1,12 @@
+// RUN: mlir-link %s %S/Inputs/opaque.mlir | FileCheck %s
+// CHECK-DAG: llvm.mlir.global external @g1() {{.*}} : !llvm.struct<"B", (struct<"C", (struct<"A", ()>)>, struct<"C", (struct<"A", ()>)>, ptr)>
+// CHECK-DAG: llvm.mlir.global external @g2() {{.*}} : !llvm.struct<"A", ()>
+// CHECK-DAG: llvm.mlir.global external @g3() {{.*}} : !llvm.struct<"B.1", (struct<"D", (struct<"E", opaque>)>, struct<"E", opaque>, ptr)>
+
+module {
+  llvm.mlir.global external @g1() {addr_space = 0 : i32} : !llvm.struct<"B", (struct<"C", (struct<"A", opaque>)>, struct<"C", (struct<"A", opaque>)>, ptr)>
+  llvm.func @use_g1() -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @g1 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+}


### PR DESCRIPTION
This modifies the workaround in #34.
If an opaque type name collides with a different named type, the opaque type takes the specified body now, instead of being renamed.