### PR TITLE
[MLIR][mlir-link] Add structors in llvm ctors/dtors ops to dependencies 

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMLinkerInterface.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMLinkerInterface.h
@@ -25,6 +25,7 @@ public:
   static uint32_t getAddressSpace(Operation *op);
   StringRef getSymbol(Operation *op) const override;
   Operation *materialize(Operation *src, link::LinkState &state) const override;
+  SmallVector<Operation *> dependencies(Operation *op) const override;
   Operation *appendGlobals(llvm::StringRef glob, link::LinkState &state);
 
   template <typename structor_t>

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMLinkerInterface.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMLinkerInterface.h
@@ -30,12 +30,14 @@ public:
 
   template <typename structor_t>
   Operation *appendGlobalStructors(link::LinkState &state) {
-    ArrayRef<Operation *> toLink;
+    ArrayRef<Operation *> toLink{};
 
     if constexpr (std::is_same<LLVM::GlobalCtorsOp, structor_t>()) {
-      toLink = append.lookup("llvm.global_ctors");
+      if (auto found = append.find("llvm.global_ctors"); found != append.end())
+        toLink = append.find("llvm.global_ctors")->second;
     } else if constexpr (std::is_same<LLVM::GlobalDtorsOp, structor_t>()) {
-      toLink = append.lookup("llvm.global_dtors");
+      if (auto found = append.find("llvm.global_ctors"); found != append.end())
+        toLink = append.find("llvm.global_ctors")->second;
     }
 
     std::vector<Attribute> newStructorList;

--- a/mlir/test/mlir-link/global-structors-a.mlir
+++ b/mlir/test/mlir-link/global-structors-a.mlir
@@ -1,0 +1,19 @@
+// RUN: mlir-link -sort-symbols -split-input-file %s | FileCheck %s
+
+// CHECK: llvm.func internal @bar
+// CHECK: llvm.func internal @foo
+// CHECK: llvm.mlir.global_ctors ctors = [@foo]
+// CHECK: llvm.mlir.global_dtors dtors = [@bar]
+
+llvm.mlir.global_ctors ctors = [@foo], priorities = [65535 : i32], data = [#llvm.zero]
+llvm.func internal @foo() -> i32 {
+  %0 = llvm.mlir.constant(0 : i32) : i32
+  llvm.return %0 : i32
+}
+
+// -----
+llvm.mlir.global_dtors dtors = [@bar], priorities = [65535 : i32], data = [#llvm.zero]
+llvm.func internal @bar() -> i32 {
+  %0 = llvm.mlir.constant(0 : i32) : i32
+  llvm.return %0 : i32
+}


### PR DESCRIPTION
LLVM dialect Global{C,D}torsOp references symbols in special attributes.
This needs to be handled as a special case for symbol dependency
computation.