### PR TITLE
[CIR] Fix parsing of #cir.unwind and cir.resume for catch regions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1030,9 +1030,8 @@ def ResumeOp : CIR_Op<"resume", [ReturnLike, Terminator,
                        Optional<CIR_UInt32>:$type_id,
                        UnitAttr:$rethrow);
   let assemblyFormat = [{
-    ($rethrow^)?
-    ($exception_ptr^)?
-    (`,` $type_id^)?
+    (`rethrow` $rethrow^)?
+    ($exception_ptr^(`,` $type_id^)?)?
     attr-dict
   }];
 }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1486,26 +1486,27 @@ ParseResult parseCatchRegions(
   };
 
   auto parseCatchEntry = [&]() -> ParseResult {
-    mlir::Type exceptionType;
     mlir::Attribute exceptionTypeInfo;
 
-    // FIXME: support most recent syntax, currently broken.
-    ::llvm::StringRef attrStr;
-    if (!parser.parseOptionalKeyword(&attrStr, {"all"})) {
-      if (parser.parseKeyword("type").failed())
+    if (parser.parseOptionalAttribute(exceptionTypeInfo).has_value()) {
+      catchList.push_back(exceptionTypeInfo);
+    } else {
+      ::llvm::StringRef attrStr;
+      if (parser.parseOptionalKeyword(&attrStr, {"all"}).succeeded()) {
+        // "all" keyword found, exceptionTypeInfo remains null
+      } else if (parser.parseOptionalKeyword("type").succeeded()) {
+        if (parser.parseAttribute(exceptionTypeInfo).failed())
+          return parser.emitError(parser.getCurrentLocation(),
+                                  "expected valid RTTI info attribute");
+      } else {
         return parser.emitError(parser.getCurrentLocation(),
-                                "expected 'type' keyword here");
-      if (parser.parseType(exceptionType).failed())
-        return parser.emitError(parser.getCurrentLocation(),
-                                "expected valid exception type");
-      if (parser.parseAttribute(exceptionTypeInfo).failed())
-        return parser.emitError(parser.getCurrentLocation(),
-                                "expected valid RTTI info attribute");
+                                "expected attribute, 'all', or 'type' keyword");
+      }
+      catchList.push_back(exceptionTypeInfo);
     }
-    catchList.push_back(exceptionTypeInfo);
     return parseAndCheckRegion();
   };
-
+  
   if (parser.parseKeyword("catch").failed())
     return parser.emitError(parser.getCurrentLocation(),
                             "expected 'catch' keyword here");

--- a/llvm/.gitignore
+++ b/llvm/.gitignore
@@ -66,3 +66,6 @@ docs/_build
 .sw?
 #OS X specific files.
 .DS_store
+#Temp files specific to instafix-llvm
+out
+CMakePresets.json


### PR DESCRIPTION
1. **Catch Entry Parsing**: `parseCatchEntry` in `CIRDialect.cpp` now properly handles `#cir.unwind` attributes

2. **Resume Operation**: Fix record definition of `cir.resume` in order to handle locations correctly

## Issue:
- `error: expected '{' to begin a region` when parsing `catch [#cir.unwind {`
- `error: undefined symbol alias id` when parsing `cir.resume loc(#loc)`