### PR TITLE
[ClangIR] Added fallback implementation for intrinsics

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -2499,6 +2499,10 @@ public:
   mlir::LogicalResult emitWhileStmt(const clang::WhileStmt &S);
 
   mlir::Value emitX86BuiltinExpr(unsigned BuiltinID, const CallExpr *E);
+  // Fallback support for unsupported intrinsics
+  mlir::Value emitX86IntrinsicFallback(unsigned BuiltinID, const CallExpr *E,
+                                       llvm::ArrayRef<mlir::Value> Ops);
+  std::string convertBuiltinToIntrinsicName(llvm::StringRef builtinName);
 
   /// CIR build helpers
   /// -----------------

--- a/llvm/.gitignore
+++ b/llvm/.gitignore
@@ -66,5 +66,3 @@ docs/_build
 .sw?
 #OS X specific files.
 .DS_store
-CMakePresets.json
-out/


### PR DESCRIPTION
Added some commits that was previously added onto the incubator, which were simple support for some SIMD intrinsics.

The main contribution was implementing a generic fallback system for unsupported X86 intrinsics. Instead of manually implementing hundreds of SIMD intrinsics, the system automatically translates unknown ClangIR builtins (like `__builtin_ia32_kshiftliqi`) into their corresponding LLVM intrinsic calls (like `llvm.x86.avx512.kshiftl.b`). This eliminates crashes and provides immediate compatibility with SIMD-heavy codebases without requiring individual intrinsic implementations.