### PR TITLE
[CIR] Fixed ClangIR linker

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -972,7 +972,7 @@ def CIR_AddressSpaceAttr :  CIR_EnumAttr<CIR_AddressSpace, "address_space"> {
   ];
 
   let assemblyFormat = [{
-    `` custom<AddressSpaceValue>($value)
+    `<` custom<AddressSpaceValue>($value) `>`
   }];
 
   let defaultValue = "cir::AddressSpace::Default";

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3971,7 +3971,10 @@ def FuncOp : CIR_Op<"func", [
 
   let arguments = (ins
     SymbolNameAttr:$sym_name,
-    CIR_VisibilityAttr:$global_visibility,
+    DefaultValuedAttr<
+      CIR_VisibilityAttr,
+      "VisibilityKind::Default"
+    >:$global_visibility,
     TypeAttrOf<CIR_FuncType>:$function_type,
     UnitAttr:$builtin,
     UnitAttr:$coroutine,

--- a/clang/include/clang/CIR/Interfaces/CIRLinkerInterface.h
+++ b/clang/include/clang/CIR/Interfaces/CIRLinkerInterface.h
@@ -12,12 +12,219 @@
 
 #ifndef CLANG_INTERFACES_CIR_CIRLINKINTERFACE_H_
 #define CLANG_INTERFACES_CIR_CIRLINKINTERFACE_H_
+#include "mlir/Linker/LLVMLinkerMixin.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include <optional>
 
 namespace mlir {
 class DialectRegistry;
 } // namespace mlir
 
+using namespace mlir;
+using namespace mlir::link;
+
 namespace cir {
+//===----------------------------------------------------------------------===//
+// CIRSymbolLinkerInterface
+//===----------------------------------------------------------------------===//
+
+class CIRSymbolLinkerInterface
+    : public SymbolAttrLLVMLinkerInterface<CIRSymbolLinkerInterface> {
+public:
+  CIRSymbolLinkerInterface(Dialect *dialect)
+      : SymbolAttrLLVMLinkerInterface(dialect) {}
+
+  bool canBeLinked(Operation *op) const override {
+    return isa<cir::GlobalOp>(op) || isa<cir::FuncOp>(op);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // LLVMLinkerMixin required methods from derived linker interface
+  //===--------------------------------------------------------------------===//
+
+  // TODO: expose convertLinkage from LowerToLLVM.cpp
+  static Linkage toLLVMLinkage(cir::GlobalLinkageKind linkage) {
+    using CIR = cir::GlobalLinkageKind;
+    using LLVM = mlir::LLVM::Linkage;
+
+    switch (linkage) {
+    case CIR::AvailableExternallyLinkage:
+      return LLVM::AvailableExternally;
+    case CIR::CommonLinkage:
+      return LLVM::Common;
+    case CIR::ExternalLinkage:
+      return LLVM::External;
+    case CIR::ExternalWeakLinkage:
+      return LLVM::ExternWeak;
+    case CIR::InternalLinkage:
+      return LLVM::Internal;
+    case CIR::LinkOnceAnyLinkage:
+      return LLVM::Linkonce;
+    case CIR::LinkOnceODRLinkage:
+      return LLVM::LinkonceODR;
+    case CIR::PrivateLinkage:
+      return LLVM::Private;
+    case CIR::WeakAnyLinkage:
+      return LLVM::Weak;
+    case CIR::WeakODRLinkage:
+      return LLVM::WeakODR;
+    };
+  }
+
+  static Linkage getLinkage(Operation *op) {
+    if (auto gv = dyn_cast<cir::GlobalOp>(op))
+      return toLLVMLinkage(gv.getLinkage());
+    if (auto fn = dyn_cast<cir::FuncOp>(op))
+      return toLLVMLinkage(fn.getLinkage());
+    llvm_unreachable("unexpected operation");
+  }
+
+  static bool isComdat(Operation *op) {
+    // TODO(frabert): Extracting comdat info from CIR is not implemented yet
+    return false;
+  }
+
+  static std::optional<mlir::link::ComdatSelector>
+  getComdatSelector(Operation *op) {
+    // TODO(frabert): Extracting comdat info from CIR is not implemented yet
+    return std::nullopt;
+  }
+
+  // TODO: expose lowerCIRVisibilityToLLVMVisibility from LowerToLLVM.cpp
+  static Visibility toLLVMVisibility(cir::VisibilityAttr visibility) {
+    return toLLVMVisibility(visibility.getValue());
+  }
+
+  static Visibility toLLVMVisibility(cir::VisibilityKind visibility) {
+    using CIR = cir::VisibilityKind;
+    using LLVM = mlir::LLVM::Visibility;
+
+    switch (visibility) {
+    case CIR::Default:
+      return LLVM::Default;
+    case CIR::Hidden:
+      return LLVM::Hidden;
+    case CIR::Protected:
+      return LLVM::Protected;
+    };
+  }
+
+  static cir::VisibilityKind toCIRVisibility(Visibility visibility) {
+    using CIR = cir::VisibilityKind;
+    using LLVM = mlir::LLVM::Visibility;
+
+    switch (visibility) {
+    case LLVM::Default:
+      return CIR::Default;
+    case LLVM::Hidden:
+      return CIR::Hidden;
+    case LLVM::Protected:
+      return CIR::Protected;
+    };
+  }
+
+  static cir::VisibilityAttr toCIRVisibilityAttr(Visibility visibility,
+                                                 MLIRContext *mlirContext) {
+    return cir::VisibilityAttr::get(mlirContext, toCIRVisibility(visibility));
+  }
+
+  static Visibility getVisibility(Operation *op) {
+    if (auto gv = dyn_cast<cir::GlobalOp>(op))
+      return toLLVMVisibility(gv.getGlobalVisibility());
+    if (auto fn = dyn_cast<cir::FuncOp>(op))
+      return toLLVMVisibility(fn.getGlobalVisibility());
+    llvm_unreachable("unexpected operation");
+  }
+
+  static void setVisibility(Operation *op, Visibility visibility) {
+    if (auto gv = dyn_cast<cir::GlobalOp>(op))
+      return gv.setGlobalVisibilityAttr(
+          toCIRVisibilityAttr(visibility, op->getContext()));
+    if (auto fn = dyn_cast<cir::FuncOp>(op))
+      return fn.setGlobalVisibilityAttr(
+          toCIRVisibilityAttr(visibility, op->getContext()));
+    llvm_unreachable("unexpected operation");
+  }
+
+  static bool isDeclaration(Operation *op) {
+    if (auto gv = dyn_cast<cir::GlobalOp>(op))
+      return gv.isDeclaration();
+    if (auto fn = dyn_cast<cir::FuncOp>(op))
+      return fn.isDeclaration();
+    llvm_unreachable("unexpected operation");
+  }
+
+  static unsigned getBitWidth(Operation *op) { llvm_unreachable("NYI"); }
+
+  // FIXME: CIR does not yet have UnnamedAddr attribute
+  static UnnamedAddr getUnnamedAddr(Operation * /* op*/) {
+    return UnnamedAddr::Global;
+  }
+
+  // FIXME: CIR does not yet have UnnamedAddr attribute
+  static void setUnnamedAddr(Operation * /* op*/, UnnamedAddr addr) {}
+
+  static std::optional<uint64_t> getAlignment(Operation *op) {
+    if (auto gv = dyn_cast<cir::GlobalOp>(op))
+      return gv.getAlignment();
+    // FIXME: CIR does not (yet?) have alignment for functions
+    llvm_unreachable("unexpected operation");
+  }
+
+  static void setAlignment(Operation *op, std::optional<uint64_t> align) {
+    if (auto gv = dyn_cast<cir::GlobalOp>(op))
+      return gv.setAlignment(align);
+    // FIXME: CIR does not (yet?) have alignment for functions
+    llvm_unreachable("unexpected operation");
+  }
+
+  static bool isConstant(Operation *op) {
+    if (auto gv = dyn_cast<cir::GlobalOp>(op))
+      return gv.getConstant();
+    llvm_unreachable("unexpected operation");
+  }
+
+  static void setIsConstant(Operation *op, bool value) {
+    if (auto gv = dyn_cast<cir::GlobalOp>(op))
+      return gv.setConstant(value);
+    llvm_unreachable("constness setting allowed only for globals");
+  }
+
+  static bool isGlobalVar(Operation *op) { return isa<cir::GlobalOp>(op); }
+
+  static llvm::StringRef getSection(Operation *op) {
+    if (auto gv = dyn_cast<cir::GlobalOp>(op)) {
+      auto section = gv.getSection();
+      return section ? section.value() : llvm::StringRef();
+    }
+    // FIXME: CIR func does not yet have section attribute
+    llvm_unreachable("unexpected operation");
+  }
+
+  static std::optional<cir::AddressSpaceAttr> getAddressSpace(Operation *op) {
+    if (auto gv = dyn_cast<cir::GlobalOp>(op)) {
+      if (auto addrSpace = gv.getAddrSpaceAttr()) {
+        return addrSpace;
+      }
+      return std::nullopt;
+    }
+
+    llvm_unreachable("unexpected operation");
+  }
+
+  Operation *materialize(Operation *src, LinkState &state) const override {
+    return cloneCIROperationPreservingAttributes(src, state);
+  }
+
+private:
+  Operation *cloneCIROperationPreservingAttributes(Operation *src,
+                                                   LinkState &state) const;
+  Operation *cloneCIRGlobal(cir::GlobalOp src, LinkState &state,
+                            IRMapping &mapping) const;
+  Operation *cloneCIRFunction(cir::FuncOp src, LinkState &state,
+                              IRMapping &mapping) const;
+};
+
 void registerLinkerInterface(mlir::DialectRegistry &registry);
 } // namespace cir
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2743,6 +2743,14 @@ cir::FuncOp CIRGenModule::createCIRFunction(mlir::Location loc, StringRef name,
     mlir::SymbolTable::setSymbolVisibility(
         f, mlir::SymbolTable::Visibility::Private);
 
+    // Set default CIR global_visibility attribute to avoid verification errors
+    if (fd) {
+      f.setGlobalVisibilityAttr(getGlobalVisibilityAttrFromDecl(fd));
+    } else {
+      // Default to hidden visibility for declarations without a FunctionDecl
+      f.setGlobalVisibilityAttr(cir::VisibilityAttr::get(&getMLIRContext(), cir::VisibilityKind::Hidden));
+    }
+
     // Initialize with empty dict of extra attributes.
     f.setExtraAttrsAttr(
         cir::ExtraFuncAttributesAttr::get(builder.getDictionaryAttr({})));


### PR DESCRIPTION
## 🎯 **List of Necessary Changes**

### **Problem 1: TableGen Parsing Corruption**
- **Symptom**: `address_spacedefault` instead of `#cir.address_space<default>`
- **Root Cause**: Missing delimiters in TableGen assembly format
- **Solution**: Added `<>` delimiters to `CIRAttrs.td`

### **Problem 2: Missing Required Attributes**  
- **Symptom**: "missing required attribute 'global_visibility'" verification errors
- **Root Cause**: CIR operations created without default visibility values
- **Solution**: Added default values in `CIROps.td` and `CIRGenModule.cpp`

### **Problem 3: MLIR Verification Conflicts**
- **Symptom**: "symbol declaration cannot have public visibility" errors
- **Root Cause**: MLIR's general verification rules conflict with CIR-specific rules
- **Solution**: Set `sym_visibility = "private"` for all CIR operations in linker interface

### **Problem 4: Attribute Corruption During Linking**
- **Symptom**: CIR attributes getting corrupted during symbol linking
- **Root Cause**: Standard MLIR cloning doesn't preserve CIR attribute syntax
- **Solution**: Custom CIR-aware cloning in `CIRLinkerInterface.cpp`


I had also moved `CIRSymbolLinkerInterface` in implementation file.
